### PR TITLE
Webhook validation algorithm update to ed25519

### DIFF
--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -8,11 +8,11 @@ const Express = require('express');
  * makes this really easy.
  *
  * To run this file, just provide your Secret API Key and Webhook Secret, like so:
- * TELNYX_API_KEY=KEYXXX PUBLIC_KEY=ZZZXXX node express.js
+ * TELNYX_API_KEY=KEYXXX TELNYX_PUBLIC_KEY=ZZZXXX node express.js
  */
 
 const apiKey = process.env.TELNYX_API_KEY;
-const publicKey = process.env.WEBHOOK_SECRET;
+const publicKey = process.env.TELNYX_PUBLIC_KEY;
 
 const telnyx = Telnyx(apiKey);
 

--- a/examples/webhook-signing/package.json
+++ b/examples/webhook-signing/package.json
@@ -10,6 +10,6 @@
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
     "morgan": "^1.8.1",
-    "telnyx": "^0.1.0"
+    "telnyx": "^1.0.0"
   }
 }

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -17,7 +17,7 @@ var Webhook = {
 };
 
 var signature = {
-  verifySignature: function(payload, signatureHeader, timestampHeader, publicKey, tolerance) {
+  verifySignature: function(payload, signatureHeader = '', timestampHeader = '', publicKey, tolerance) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
     timestampHeader = Buffer.isBuffer(timestampHeader) ? timestampHeader.toString('utf8') : timestampHeader;
 

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Buffer = require('safe-buffer').Buffer;
-var crypto = require('crypto');
+var ed25519 = require('ed25519');
 
 var Error = require('./Error');
 
@@ -19,27 +19,23 @@ var Webhook = {
 var signature = {
   verifySignature: function(payload, signatureHeader, timestampHeader, publicKey, tolerance) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
-    signatureHeader = Buffer.isBuffer(signatureHeader) ? signatureHeader.toString('utf8') : signatureHeader;
     timestampHeader = Buffer.isBuffer(timestampHeader) ? timestampHeader.toString('utf8') : timestampHeader;
 
-    signature = Buffer.from(signatureHeader, 'base64');
-    const signedPayload = `${timestampHeader}|${payload}`;
+    var payloadBuffer = Buffer.from(`${timestampHeader}|${payload}`, 'utf8');
 
-    const verifier = crypto.createVerify('sha256');
-    verifier.update(signedPayload);
-    verifier.end();
+    // eslint-disable-next-line new-cap
+    var keyPair = ed25519.MakeKeypair(Buffer.from(publicKey, 'base64'));
+    var verification;
 
-    const verification = verifier.verify(publicKey, signature);
+    try {
+      // eslint-disable-next-line new-cap
+      verification = ed25519.Verify(payloadBuffer, signatureHeader, keyPair.publicKey);
+    } catch (err) {
+      throwSignatureVerificationError(payload, signatureHeader, timestampHeader);
+    }
 
     if (!verification) {
-      throw new Error.TelnyxSignatureVerificationError({
-        message: 'Signature is invalid and does not match the payload',
-        detail: {
-          signatureHeader: signatureHeader,
-          timestampHeader: timestampHeader,
-          payload: payload,
-        },
-      });
+      throwSignatureVerificationError(payload, signatureHeader, timestampHeader);
     }
 
     var timestampAge = Math.floor(Date.now() / 1000) - parseInt(timestampHeader, 10);
@@ -58,6 +54,17 @@ var signature = {
     return true;
   },
 };
+
+function throwSignatureVerificationError(payload, signatureHeader, timestampHeader) {
+  throw new Error.TelnyxSignatureVerificationError({
+    message: 'Signature is invalid and does not match the payload',
+    detail: {
+      signatureHeader: signatureHeader,
+      timestampHeader: timestampHeader,
+      payload: payload,
+    },
+  });
+}
 
 Webhook.signature = signature;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,6 +291,14 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -684,6 +692,15 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ed25519": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ed25519/-/ed25519-0.0.4.tgz",
+      "integrity": "sha1-5WIYrOL8kD0llZOu8LKpY59HW+s=",
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.0.9"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -919,6 +936,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-cache-dir": {
       "version": "2.1.0",
@@ -1652,6 +1674,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
+    "ed25519": "0.0.4",
     "lodash.isplainobject": "^4.0.6",
     "qs": "^6.6.0",
     "safe-buffer": "^5.1.1",

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -84,6 +84,10 @@ describe('Webhooks', function() {
       }).to.throw(expectedMessage);
 
       expect(function() {
+        telnyx.webhooks.signature.verifySignature(EVENT_PAYLOAD_STRING, undefined, timestamp, PUBLIC_KEY);
+      }).to.throw(expectedMessage);
+
+      expect(function() {
         telnyx.webhooks.signature.verifySignature(EVENT_PAYLOAD_STRING, Buffer.from('foo', 'ascii'), timestamp, PUBLIC_KEY);
       }).to.throw(expectedMessage);
     });

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -4,23 +4,32 @@ var telnyx = require('../testUtils').getSpyableTelnyx();
 var expect = require('chai').expect;
 var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
+var ed25519 = require('ed25519');
 
 var EVENT_PAYLOAD = {
   data: {
     record_type: 'event',
     id: '0ccc7b54-4df3-4bca-a65a-3da1ecc777f0',
-    event_type: 'port_request.ported',
-    occurred_at: '2018-02-02T22:25:27.521992Z',
+    event_type: 'call_initiated',
+    created_at: '2018-02-02T22:25:27.521992Z',
     payload: {
-      id: '5ccc7b54-4df3-4bca-a65a-3da1ecc777f0'
+      to: '+13129457420',
+      start_time: '2018-02-02T22:25:27.521992Z',
+      occurred_at: '2018-02-02T22:25:27.521992Z',
+      from: '+35319605860',
+      call_control_id: 'AgDIxmoRX6QMuaIj_uXRXnPAXP0QlNfXczRrZvZakpWxBlpw48KyZQ==',
+      connection_id: '7267xxxxxxxxxxxxxx',
+      call_leg_id: '428c31b6-7af4-4bcb-b7f5-5013ef9657c1',
+      call_session_id: '428c31b6-abf3-3bc1-b7f4-5013ef9657c1',
+      client_state: 'aGF2ZSBhIG5pY2UgZGF5ID1d',
+      direction: 'incoming',
+      state: 'parked'
     }
   }
 };
 var EVENT_PAYLOAD_STRING = JSON.stringify(EVENT_PAYLOAD, null, 2);
 
-var PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwy/jPkkgBo7oQermYujj\nAmSqN+aHNg+D4K85lKn6T3khJ8O2t/FrgN5qSGqg+0U5hoIHZflEon28lbLdf6gZ\njPeKQ2a24w5zroR6e4MM00RyJWA6MWXdo6Tn6xqKMYuT8LffEJGnXCH4yTIkxAVD\nyK0dfewhtrlpmW5ojXcDCrZ3Oo1o588PLNwSIuQwU7wHZwOLglWxFt6LZ9Ps8zYf\nQNH/pXNczf1E4rGZ1QxrzqFbndvjCE5VDRhULhycT/X0H2EMvNgHsDQk4OhENnzo\nCal3vO5+P9MgC7NSZCR8Ubebq0tanL5dj5GGYyjWmeq3QhfDLX2mTpIv/B0e8+hg\n8QIDAQAB\n-----END PUBLIC KEY-----\n';
-
-var PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAwy/jPkkgBo7oQermYujjAmSqN+aHNg+D4K85lKn6T3khJ8O2\nt/FrgN5qSGqg+0U5hoIHZflEon28lbLdf6gZjPeKQ2a24w5zroR6e4MM00RyJWA6\nMWXdo6Tn6xqKMYuT8LffEJGnXCH4yTIkxAVDyK0dfewhtrlpmW5ojXcDCrZ3Oo1o\n588PLNwSIuQwU7wHZwOLglWxFt6LZ9Ps8zYfQNH/pXNczf1E4rGZ1QxrzqFbndvj\nCE5VDRhULhycT/X0H2EMvNgHsDQk4OhENnzoCal3vO5+P9MgC7NSZCR8Ubebq0ta\nnL5dj5GGYyjWmeq3QhfDLX2mTpIv/B0e8+hg8QIDAQABAoIBAQCNwoP6wsVdvgD1\njxNQlu/41v/Bpc5h9xbC4sChNmqzubfY144nPlHjwKXUfoz4sag8Bsg0ybuNgGCt\nIME6a+5SsZ5boYgGlIJ0J4eFmQKBll6IwsDBC8jTh3thB1+C6GrEE+cQc5jnk0zL\nY33MWD6IyyJ2SD+cJEGLy+JnjB5LckGCQXWPQXwvpIKgGmFoLQzHCKfeKHZ3olB8\nC1+YKrQzLtyuuH9obDWxRSrqI5gOI/76PWmo+weNa4OrfFtBf5O9bo5OD17ilIT/\nuNpxb/7rOkpwU9x6D00/D/S7ecCdVoL2yBB5L635TNQKXxhvdSmBg1ceLlztwsUL\nOHIlglTZAoGBAOY3wyincm8iAUxLE+Z3AeTD94pjND4g2JXFF9E7UDxgRD6E3n38\nubNRdAMkxDmDYgyIOZsebykMadQ2vNiWqTjOBr6hxyQMFutHWrIJOU+peFCepn8u\nNX3Xg44l7KcwwqX5svoqgFl1FKwNpBOSo50oGX4lAgqtjYqEeMInfjZ7AoGBANkL\nz0wBNAr9oXsc0BN2WkQXB34RU/WcrymhxHfc+ZRzRShk9LOdBTuMYnj4rtjdG849\nJDDWlMk7UlzGjI07G5aT+n8Aq69BhV0IARC9PafTncE6G3sHswAQudHiurLflP9C\noj6kTakunrq8Kgj3Q1p6Ie+Hv7E01A3D0Difr4CDAoGAXORrLuBB4G3MMEirAvdK\nIFCidYiJ7/e47NXWQmq4eWQupTtfu15aX+yh7xLKypok2gGtnNWu7NVBbouXr507\nMtyPBCSrAfSO2uizw9rM8UPkdENP00mF8/0d7CGJV/zozafve9niaDZB3Rqz9eHZ\nevRPNQMhy8Uzs4y4XT8qQjkCgYBNuLjmkpe8R86Hc23fSkZQk56POk1CanUfB1p/\nQZXt3skpCd3GY7f39vFcOFEEP0kxtRs8kdp9pMx9hGvYNw5OAXd1+xt/iorjIXag\nM+PcMR8QjmpAyCUFJPglfHc2jnGgZpAKtnNI3fThEXhL9Z8cyxdT2tx97FjzBOeP\nHz+NWQKBgQCU0bSxTp2rbOCxHosQ/GDDTY0JkQ2z5q1SkibSiEnyAZ3yCHpXZRD7\nsa5BWs4qlasSKmxdmT9xgRDAL6CJH6kJizF3UIaIPOvPjIroOa7Mk1OFNbOi6Cao\n0LcWp5w1I2r5g7sOIRM/AcS3yVT5RJO4KB8WyDOvxCfP8cFsTacZmQ==\n-----END RSA PRIVATE KEY-----\n';
+var PUBLIC_KEY = crypto.randomBytes(32);
 
 describe('Webhooks', function() {
   describe('.constructEvent', function() {
@@ -128,13 +137,9 @@ function generateSignature(opts) {
 
   opts.timestamp = opts.timestamp || Math.floor(Date.now() / 1000).toString();
   opts.payload = opts.payload || EVENT_PAYLOAD_STRING;
-  opts.publicKey = opts.publicKey || PUBLIC_KEY;
-  opts.privateKey = opts.privateKey || PRIVATE_KEY;
 
-  const sign = crypto.createSign('SHA256');
-  sign.write(`${opts.timestamp}|${opts.payload}`);
-  sign.end();
-  const signature = sign.sign(opts.privateKey, 'base64');
+  var payload = Buffer.from(`${opts.timestamp}|${opts.payload}`, 'utf8');
 
-  return signature;
+  // eslint-disable-next-line new-cap
+  return ed25519.Sign(payload, ed25519.MakeKeypair(Buffer.from(PUBLIC_KEY, 'base64')));
 }


### PR DESCRIPTION
The current SDK uses an RSA algorithm to sign webhooks. We are moving to an `ed25519` algorithm. There are 3 variables in verifying the signature in a webhook:

1. signature: Webhooks will have a header with key telnyx-signature-ed25519 containing an ASCII string - this is the webhook signature.

2. public_key: Each user has a public key which is also an ASCII string. This can be acquired from the Portal but it's currently not public-facing (https://portal.telnyx.com/#/app/account/public-key).

3. payload: The final variable is a concatenation of the webhook timestamp (in the header telnyx-timestamp), a pipe (|), and the body of the webhook in bytes - it's very important that this is in bytes format.
When the payload and signature are hashed using the ed25519 algorithm they can be validated against the public_key.

Reference: https://telnyx.atlassian.net/browse/DEVEX-178

In this PR, I followed an implementation similar to the other SDKs:
- [telnyx-python](https://github.com/team-telnyx/telnyx-python/commit/94330d60ed780b08c9762b97cf53b068fe78f9c0#diff-e3557ab436e44f0d7ad749a77c215ba8)
- [telnyx-ruby](https://github.com/team-telnyx/telnyx-ruby/commit/2493f1bf5da0f89274e51be415e076b01570d138)
