### PR TITLE
Nested resources custom attributes assign

### DIFF
--- a/lib/TelnyxMethod.js
+++ b/lib/TelnyxMethod.js
@@ -46,16 +46,18 @@ function telnyxMethod(spec) {
 }
 
 /**
- * Nested resources related method to populate nest method URL with matching resource object attributes.
- * e.g.: use `call_control_id` attribute from `call`.
- * That if exists in call object or in `call.create()` response data
+ * Populate nested method URL params with resource object attributes that match the param name.
+ * This allows you to do things like setting the `call_control_id` attribute from an existing call object on a new instance of `telnyx.calls`.
  */
 function populateUrlParamsWithResource(self, args, spec) {
   // if url params is not in resource response data.
   if (!spec.paramsValues[0]) {
-    spec.paramsValues = spec.paramsNames.map(function(name) {
-      return self[name];
-    });
+    spec.paramsValues = spec.paramsNames.reduce(function(result, name) {
+      if (self[name]) {
+        result.push(self[name]);
+      }
+      return result;
+    }, []);
   }
 
   args.unshift(spec.paramsValues);

--- a/lib/TelnyxMethod.js
+++ b/lib/TelnyxMethod.js
@@ -14,9 +14,10 @@ var makeAutoPaginationMethods = require('./autoPagination').makeAutoPaginationMe
  *  must be passed by the consumer of the API. Subsequent optional arguments are
  *  optionally passed through a hash (Object) as the penultimate argument
  *  (preceding the also-optional callback argument
- * @param [spec.urlParamsValues=[]] Array of required arguments in the order that they
+ * @param [spec.paramsNames=[]] Array of required arguments in the order that they
  *  are to be used instead of being passed by the consumer of the API. Useful for nested resources
  *  in a manner that consumer doesn't need to provide path arguments
+ * @param [spec.paramsValues=[]] Array of substitute require arguments in `paramsNames` values
  * @param [spec.encode] Function for mutating input parameters to a method.
  *  Usefully for applying transforms to data on a per-method basis.
  * @param [spec.host] Hostname for the request.
@@ -27,8 +28,8 @@ function telnyxMethod(spec) {
     var self = this;
     var args = [].slice.call(arguments);
 
-    if (spec.urlParamsValues) {
-      args.unshift(spec.urlParamsValues);
+    if (spec.paramsValues) {
+      populateUrlParamsWithResource(self, args, spec);
     }
 
     var callback = typeof args[args.length - 1] == 'function' && args.pop();
@@ -42,6 +43,22 @@ function telnyxMethod(spec) {
 
     return requestPromise;
   };
+}
+
+/**
+ * Nested resources related method to populate nest method URL with matching resource object attributes.
+ * e.g.: use `call_control_id` attribute from `call`.
+ * That if exists in call object or in `call.create()` response data
+ */
+function populateUrlParamsWithResource(self, args, spec) {
+  // if url params is not in resource response data.
+  if (!spec.paramsValues[0]) {
+    spec.paramsValues = spec.paramsNames.map(function(name) {
+      return self[name];
+    });
+  }
+
+  args.unshift(spec.paramsValues);
 }
 
 module.exports = telnyxMethod;

--- a/lib/resources/Calls.js
+++ b/lib/resources/Calls.js
@@ -24,11 +24,12 @@ function nestedMethods(callControlId) {
     'send_dtmf',
     'transfer'
   ].forEach(function(name) {
-    commands[name] = telnyxMethod({
+    commands[name] = commands[utils.snakeToCamelCase(name)] = telnyxMethod({
       method: 'POST',
-      path: `/{callControlId}/actions/${name}`,
-      urlParams: ['callControlId'],
-      urlParamsValues: [callControlId],
+      path: `/{call_control_id}/actions/${name}`,
+      urlParams: ['call_control_id'],
+      paramsValues: [callControlId],
+      paramsNames: ['call_control_id'],
       methodType: 'create',
     })
   });

--- a/lib/resources/Calls.js
+++ b/lib/resources/Calls.js
@@ -4,37 +4,35 @@ var TelnyxResource = require('../TelnyxResource');
 var utils = require('../utils');
 var telnyxMethod = TelnyxResource.method;
 
-function nestedMethods(callControlId) {
-  var commands = {};
+var CALL_COMMANDS = [
+  'answer',
+  'reject',
+  'hangup',
+  'bridge',
+  'speak',
+  'fork_start',
+  'fork_stop',
+  'gather_using_audio',
+  'gather_using_speak',
+  'playback_start',
+  'playback_stop',
+  'record_start',
+  'record_stop',
+  'send_dtmf',
+  'transfer'
+];
 
-  [
-    'answer',
-    'reject',
-    'hangup',
-    'bridge',
-    'speak',
-    'fork_start',
-    'fork_stop',
-    'gather_using_audio',
-    'gather_using_speak',
-    'playback_start',
-    'playback_stop',
-    'record_start',
-    'record_stop',
-    'send_dtmf',
-    'transfer'
-  ].forEach(function(name) {
-    commands[name] = commands[utils.snakeToCamelCase(name)] = telnyxMethod({
+function getSpec(callControlId) {
+  return function(methodName) {
+    return {
       method: 'POST',
-      path: `/{call_control_id}/actions/${name}`,
+      path: `/{call_control_id}/actions/${methodName}`,
       urlParams: ['call_control_id'],
       paramsValues: [callControlId],
       paramsNames: ['call_control_id'],
       methodType: 'create',
-    })
-  });
-
-  return commands;
+    }
+  }
 }
 
 module.exports = require('../TelnyxResource').extend({
@@ -49,7 +47,7 @@ module.exports = require('../TelnyxResource').extend({
         response,
         telnyx,
         'calls',
-        nestedMethods(response.data.call_control_id)
+        utils.createNestedMethods(telnyxMethod, CALL_COMMANDS, getSpec(response.data.call_control_id))
       );
     },
   }),

--- a/lib/resources/Conferences.js
+++ b/lib/resources/Conferences.js
@@ -4,27 +4,25 @@ var TelnyxResource = require('../TelnyxResource');
 var utils = require('../utils');
 var telnyxMethod = TelnyxResource.method;
 
-function nestedMethods(conferenceId) {
-  var conferences = {};
+var CONFERENCES = [
+  'join',
+  'mute',
+  'unmute',
+  'hold',
+  'unhold',
+];
 
-  [
-    'join',
-    'mute',
-    'unmute',
-    'hold',
-    'unhold',
-  ].forEach(function(name) {
-    conferences[name] = telnyxMethod({
+function getSpec(conferenceId) {
+  return function(methodName) {
+    return {
       method: 'POST',
-      path: `/{conferenceId}/actions/${name}`,
+      path: `/{conferenceId}/actions/${methodName}`,
       urlParams: ['conferenceId'],
       paramsValues: [conferenceId],
       paramsNames: ['id'],
       methodType: 'create',
-    })
-  });
-
-  return conferences;
+    }
+  }
 }
 
 module.exports = require('../TelnyxResource').extend({
@@ -39,7 +37,7 @@ module.exports = require('../TelnyxResource').extend({
         response,
         telnyx,
         'conferences',
-        nestedMethods(response.data.id)
+        utils.createNestedMethods(telnyxMethod, CONFERENCES, getSpec(response.data.id))
       );
     },
   }),

--- a/lib/resources/Conferences.js
+++ b/lib/resources/Conferences.js
@@ -18,7 +18,8 @@ function nestedMethods(conferenceId) {
       method: 'POST',
       path: `/{conferenceId}/actions/${name}`,
       urlParams: ['conferenceId'],
-      urlParamsValues: [conferenceId],
+      paramsValues: [conferenceId],
+      paramsNames: ['id'],
       methodType: 'create',
     })
   });

--- a/lib/resources/MessagingProfiles.js
+++ b/lib/resources/MessagingProfiles.js
@@ -19,7 +19,7 @@ function nestedMethods(messagingProfileId) {
       paramsValues: [messagingProfileId],
       paramsNames: ['id'],
       methodType: 'list',
-    })
+    });
   });
 
   return methods;

--- a/lib/resources/MessagingProfiles.js
+++ b/lib/resources/MessagingProfiles.js
@@ -12,33 +12,53 @@ function nestedMethods(messagingProfileId) {
     'sender_ids',
     'short_codes',
   ].forEach(function(name) {
-    methods[name] = telnyxMethod({
+    methods[name] = methods[utils.snakeToCamelCase(name)] = telnyxMethod({
       method: 'GET',
       path: `/{messagingProfileId}/${name}`,
       urlParams: ['messagingProfileId'],
-      urlParamsValues: [messagingProfileId],
-      methodType: 'create',
+      paramsValues: [messagingProfileId],
+      paramsNames: ['id'],
+      methodType: 'list',
     })
   });
 
   return methods;
 }
 
+function transformResponseData(response, telnyx) {
+  const methods = nestedMethods(response.data.id);
+  methods.del = telnyxMethod({
+    method: 'DELETE',
+    path: '/{messagingProfileId}',
+    urlParams: ['messagingProfileId'],
+    paramsValues: [response.data.id],
+    paramsNames: ['id'],
+  });
+
+  return utils.addResourceToResponseData(
+    response,
+    telnyx,
+    'messagingProfiles',
+    methods,
+  );
+}
+
 module.exports = require('../TelnyxResource').extend({
   path: 'messaging_profiles',
-  includeBasic: ['list', 'retrieve', 'del', 'update'],
+  includeBasic: ['list', 'del', 'update'],
 
   create: telnyxMethod({
     method: 'POST',
 
-    transformResponseData: function(response, telnyx) {
-      return utils.addResourceToResponseData(
-        response,
-        telnyx,
-        'messagingProfiles',
-        nestedMethods(response.data.id)
-      );
-    },
+    transformResponseData: transformResponseData,
+  }),
+
+  retrieve: telnyxMethod({
+    method: 'GET',
+    path: '/{id}',
+    urlParams: ['id'],
+
+    transformResponseData: transformResponseData,
   }),
 
   listPhoneNumbers: telnyxMethod({

--- a/lib/resources/MessagingProfiles.js
+++ b/lib/resources/MessagingProfiles.js
@@ -39,7 +39,7 @@ function transformResponseData(response, telnyx) {
     response,
     telnyx,
     'messagingProfiles',
-    methods,
+    methods
   );
 }
 

--- a/lib/resources/MessagingProfiles.js
+++ b/lib/resources/MessagingProfiles.js
@@ -4,29 +4,28 @@ var TelnyxResource = require('../TelnyxResource');
 var utils = require('../utils');
 var telnyxMethod = TelnyxResource.method;
 
-function nestedMethods(messagingProfileId) {
-  var methods = {};
+var ACTIONS = [
+  'phone_numbers',
+  'sender_ids',
+  'short_codes',
+];
 
-  [
-    'phone_numbers',
-    'sender_ids',
-    'short_codes',
-  ].forEach(function(name) {
-    methods[name] = methods[utils.snakeToCamelCase(name)] = telnyxMethod({
+function getSpec(messagingProfileId) {
+  return function(methodName) {
+    return {
       method: 'GET',
-      path: `/{messagingProfileId}/${name}`,
+      path: `/{messagingProfileId}/${methodName}`,
       urlParams: ['messagingProfileId'],
       paramsValues: [messagingProfileId],
       paramsNames: ['id'],
       methodType: 'list',
-    });
-  });
-
-  return methods;
+    }
+  }
 }
 
 function transformResponseData(response, telnyx) {
-  const methods = nestedMethods(response.data.id);
+  const methods = utils.createNestedMethods(telnyxMethod, ACTIONS, getSpec(response.data.id));
+
   methods.del = telnyxMethod({
     method: 'DELETE',
     path: '/{messagingProfileId}',

--- a/lib/resources/NumberReservations.js
+++ b/lib/resources/NumberReservations.js
@@ -21,7 +21,8 @@ module.exports = require('../TelnyxResource').extend({
             method: 'POST',
             path: '/{numberReservationId}/actions/extend',
             urlParams: ['numberReservationId'],
-            urlParamsValues: [response.data.id],
+            paramsValues: [response.data.id],
+            paramsNames: ['id'],
             methodType: 'create',
           }),
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,6 +218,17 @@ var utils = module.exports = {
   },
 
   /**
+   * snake_case to camelCase
+   */
+  snakeToCamelCase: function(name) {
+    const words = name.split('_');
+
+    return words.reduce(function(acc, nextWord) {
+      return acc + nextWord.charAt(0).toUpperCase() + nextWord.slice(1);
+    });
+  },
+
+  /**
    * Add TelnyxResource to API response data
    *
    * @param [response] Resource response object

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -254,6 +254,23 @@ var utils = module.exports = {
     return response;
   },
 
+  /**
+   * Create multiple nested methods, in camelCase and snakeCase, using spec and method names
+   *
+   * @param [telnyxMethod] TelnyxResource Method  telnyxMethod creator
+   * @param [names=[]] Array of method names
+   * @param [spec] telnyxMethod spec creator by method name
+   */
+  createNestedMethods: function(telnyxMethod, names, spec) {
+    var methods = {};
+
+    names.forEach(function(name) {
+      methods[name] = methods[utils.snakeToCamelCase(name)] = telnyxMethod(spec(name));
+    })
+
+    return methods;
+  },
+
   emitWarning: emitWarning,
 };
 

--- a/test/resources/Calls.spec.js
+++ b/test/resources/Calls.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var telnyx = require('../../testUtils').getTelnyxMock();
+var utils = require('../../lib/utils');
 var expect = require('chai').expect;
 
 var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo';
@@ -22,7 +23,6 @@ var COMMANDS = [
   'send_dtmf',
   'transfer',
 ];
-
 
 describe('Calls Resource', function() {
   describe('Call Information', function() {
@@ -136,10 +136,15 @@ describe('Calls Resource', function() {
 
     COMMANDS.forEach(function(command) {
       describe(command, function() {
+        const camelCaseCommand = utils.snakeToCamelCase(command);
+
         it('Sends the correct request', function() {
           return telnyx.calls.create(callCreateData)
             .then(function(response) {
               const call = response.data;
+              call[utils.snakeToCamelCase(command)](callCommandsData[command] || {})
+                .then(responseFn);
+
               return call[command](callCommandsData[command] || {})
                 .then(responseFn);
             })
@@ -148,10 +153,36 @@ describe('Calls Resource', function() {
           return telnyx.calls.create(callCreateData)
             .then(function(response) {
               const call = response.data;
+              call[utils.snakeToCamelCase(command)](callCommandsData[command] || {}, TEST_AUTH_KEY)
+                .then(responseFn);
+
               return call[command](callCommandsData[command] || {}, TEST_AUTH_KEY)
                 .then(responseFn);
             })
         });
+
+        if (camelCaseCommand !== command) {
+          describe(camelCaseCommand, function() {
+            it('Sends the correct request', function() {
+              return telnyx.calls.create(callCreateData)
+                .then(function(response) {
+                  const call = response.data;
+
+                  return call[camelCaseCommand](callCommandsData[command] || {})
+                    .then(responseFn);
+                })
+            });
+            it('Sends the correct request [with specified auth]', function() {
+              return telnyx.calls.create(callCreateData)
+                .then(function(response) {
+                  const call = response.data;
+
+                  return call[camelCaseCommand](callCommandsData[command] || {}, TEST_AUTH_KEY)
+                    .then(responseFn);
+                })
+            });
+          })
+        }
       });
     });
   });

--- a/test/resources/MessagingProfiles.spec.js
+++ b/test/resources/MessagingProfiles.spec.js
@@ -9,6 +9,7 @@ var METHODS = [
   'phone_numbers',
   'sender_ids',
   'short_codes',
+  'del',
 ];
 
 describe('MessagingProfiles Resource', function() {
@@ -73,14 +74,14 @@ describe('MessagingProfiles Resource', function() {
     });
   });
 
-  describe('del', function() {
-    it('Sends the correct request', function() {
-      return telnyx.messagingProfiles.del('123')
-        .then(function(response) {
-          expect(response.data).to.include({id: '123'});
-        })
-    });
-  });
+  // describe('del', function() {
+  //   it('Sends the correct request', function() {
+  //     return telnyx.messagingProfiles.del('123')
+  //       .then(function(response) {
+  //         expect(response.data).to.include({id: '123'});
+  //       })
+  //   });
+  // });
 
   describe('list', function() {
     function responseFn(response) {
@@ -200,9 +201,13 @@ describe('MessagingProfiles Resource', function() {
 
   describe('Nested', function() {
     function responseFn(response) {
-      expect(response.data[0]).to.have.property('id');
-      expect(response.data[0]).to.have.property('record_type');
-      expect(response.data[0]).to.have.property('messaging_profile_id');
+      if (response.data.length) {
+        expect(response.data[0]).to.have.property('id');
+        expect(response.data[0]).to.have.property('record_type');
+        expect(response.data[0]).to.have.property('messaging_profile_id');
+      } else {
+        expect(response.data).to.have.property('id');
+      }
     }
 
     METHODS.forEach(function(action) {

--- a/test/resources/MessagingProfiles.spec.js
+++ b/test/resources/MessagingProfiles.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var telnyx = require('../../testUtils').getTelnyxMock();
+var utils = require('../../lib/utils');
 var expect = require('chai').expect;
 
 var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo';
@@ -73,15 +74,6 @@ describe('MessagingProfiles Resource', function() {
         })
     });
   });
-
-  // describe('del', function() {
-  //   it('Sends the correct request', function() {
-  //     return telnyx.messagingProfiles.del('123')
-  //       .then(function(response) {
-  //         expect(response.data).to.include({id: '123'});
-  //       })
-  //   });
-  // });
 
   describe('list', function() {
     function responseFn(response) {
@@ -212,6 +204,8 @@ describe('MessagingProfiles Resource', function() {
 
     METHODS.forEach(function(action) {
       describe(action, function() {
+        const camelCaseAction = utils.snakeToCamelCase(action);
+
         it('Sends the correct request', function() {
           return telnyx.messagingProfiles.create({name: 'Summer Campaign'})
             .then(function(response) {
@@ -227,6 +221,26 @@ describe('MessagingProfiles Resource', function() {
               return mp[action](TEST_AUTH_KEY)
                 .then(responseFn);
             })
+        });
+
+        describe(camelCaseAction, function() {
+          it('Sends the correct request', function() {
+            return telnyx.messagingProfiles.create({name: 'Summer Campaign'})
+              .then(function(response) {
+                const mp = response.data;
+                return mp[camelCaseAction]()
+                  .then(responseFn);
+              })
+          });
+          it('Sends the correct request [with specified auth]', function() {
+            return telnyx.messagingProfiles.create({name: 'Summer Campaign'})
+              .then(function(response) {
+                const mp = response.data;
+                return mp[camelCaseAction](TEST_AUTH_KEY)
+                  .then(responseFn);
+              })
+          });
+
         });
       });
     });


### PR DESCRIPTION
This PR is a fix to allow nested resources to use custom attributes on performing actions. For example, when we create a call we don't get the call_control_id, so if users try to run `call.create()` it will fail. With these changes, the following flow will work:

```
// grab call control id from webhook
const call_control_id = event.payload.call_control_id;
const { data: call } = await telnyx.calls.create({ 
  connection_id: 'uuid', 
  to: '+18005550199',
  from: '+18005550100' 
});

call.call_control_id = call_control_id;
call.hangup();
```

It also includes adding `camelCase` names for nested methods, like `forkStart`, `forkStop`, `sendDfmt` and it goes on.

An update in [code snippets](https://developersdev.telnyx.com/docs/api/v2/overview) is necessary once this is done.