### PR TITLE
fix error messages "undefined"

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -23,6 +23,8 @@ function otherErrorsMessage(errors) {
   } else if (count == 2) {
     return 'plus 1 other error.';
   }
+
+  return '';
 }
 
 function errorCount(errors) {
@@ -35,7 +37,7 @@ function errorCount(errors) {
 
 function message(errors) {
   if (Array.isArray(errors)) {
-    return errors[0] && errors[0].title + ' ';
+    return errors[0] && (errors[0].title || errors[0].detail) + ' ';
   } else {
     return errors;
   }

--- a/lib/Error.js
+++ b/lib/Error.js
@@ -12,16 +12,16 @@ function _Error(raw) {
   this.stack = (new Error(this.message)).stack;
 }
 
-function buildMessage(errors) {
-  return `${statusString(errors)}${idString(errors)}${message(errors)}${otherErrorsMessage(errors)}`;
+function buildMessage(raw) {
+  return `${statusString(raw)}${idString(raw)}${message(raw.errors)}${otherErrorsMessage(raw.errors)}`;
 }
 
 function otherErrorsMessage(errors) {
   var count = errorCount(errors);
   if (count > 2) {
-    return `plus ${count} other errors.`;
+    return ` plus ${count} other errors.`;
   } else if (count == 2) {
-    return 'plus 1 other error.';
+    return ' plus 1 other error.';
   }
 
   return '';
@@ -37,15 +37,15 @@ function errorCount(errors) {
 
 function message(errors) {
   if (Array.isArray(errors)) {
-    return errors[0] && (errors[0].title || errors[0].detail) + ' ';
+    return errors[0] && (` ${errors[0].title || errors[0].detail}`);
   } else {
-    return errors;
+    return ` ${errors}`;
   }
 }
 
 function statusString(raw) {
   if (raw.statusCode) {
-    return `(Status ${raw.statusCode}) `;
+    return `(Status ${raw.statusCode})`;
   } else {
     return '';
   }
@@ -53,7 +53,7 @@ function statusString(raw) {
 
 function idString(raw) {
   if (raw.requestId) {
-    return `(Request ${raw.requestId}) `;
+    return ` (Request ${raw.requestId})`;
   } else {
     return '';
   }
@@ -81,7 +81,7 @@ var TelnyxError = _Error.TelnyxError = _Error.extend({
     if (raw.message) {
       message = raw.message;
     } else {
-      message = buildMessage(raw.errors)
+      message = buildMessage(raw);
     }
     // Move from prototype def (so it appears in stringified obj)
     this.type = this.type;

--- a/lib/TelnyxResource.js
+++ b/lib/TelnyxResource.js
@@ -121,7 +121,7 @@ TelnyxResource.prototype = {
 
         // For convenience, make Request-Id easily accessible on
         // lastResponse.
-        res.requestId = headers['request-id'] || '';
+        res.requestId = headers['request-id'] || headers['x-request-id'] || '';
 
         var requestDurationMs = Date.now() - req._requestStart;
 
@@ -158,7 +158,7 @@ TelnyxResource.prototype = {
               message: 'Invalid JSON received from the Telnyx API',
               response: response,
               exception: e,
-              requestId: headers['request-id'],
+              requestId: res.requestId,
             }),
             null
           );

--- a/lib/TelnyxResource.js
+++ b/lib/TelnyxResource.js
@@ -121,7 +121,7 @@ TelnyxResource.prototype = {
 
         // For convenience, make Request-Id easily accessible on
         // lastResponse.
-        res.requestId = headers['request-id'];
+        res.requestId = headers['request-id'] || '';
 
         var requestDurationMs = Date.now() - req._requestStart;
 


### PR DESCRIPTION
SDK error messages were returning undefined in every response failing. This PR is to prevent that from happening and organizing error message class to include Request Id and Request Status, along with a well-formated message.