### PR TITLE
Alphanumeric Sender Ids Resource update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     # If changing this number, please also look it at tests config.
-    - TELNYX_MOCK_VERSION=0.3.1
+    - TELNYX_MOCK_VERSION=0.4.0
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/lib/TelnyxResource.js
+++ b/lib/TelnyxResource.js
@@ -34,6 +34,12 @@ function TelnyxResource(telnyx, urlData) {
     }, this);
   }
 
+  if (this.nestedResources) {
+    for (var resource in this.nestedResources) {
+      this[utils.pascalToCamelCase(resource)] = new this.nestedResources[resource](telnyx);
+    }
+  }
+
   this.initialize.apply(this, arguments);
 }
 

--- a/lib/resources/Messages.js
+++ b/lib/resources/Messages.js
@@ -3,4 +3,8 @@
 module.exports = require('../TelnyxResource').extend({
   path: 'messages',
   includeBasic: ['create', 'retrieve'],
+
+  nestedResources: {
+    AlphanumericSenderId: require('./MessagesAlphanumericSenderId')
+  },
 });

--- a/lib/resources/MessagesAlphanumericSenderId.js
+++ b/lib/resources/MessagesAlphanumericSenderId.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = require('../TelnyxResource').extend({
+  path: 'messages/alphanumeric_sender_id',
+  includeBasic: ['create'],
+});

--- a/lib/resources/MessagingProfiles.js
+++ b/lib/resources/MessagingProfiles.js
@@ -6,7 +6,7 @@ var telnyxMethod = TelnyxResource.method;
 
 var ACTIONS = [
   'phone_numbers',
-  'sender_ids',
+  'alphanumeric_sender_ids',
   'short_codes',
 ];
 
@@ -88,14 +88,14 @@ module.exports = require('../TelnyxResource').extend({
 
   listSenderIds: telnyxMethod({
     method: 'GET',
-    path: '/{messagingProfileId}/sender_ids',
+    path: '/{messagingProfileId}/alphanumeric_sender_ids',
     urlParams: ['messagingProfileId'],
     methodType: 'list',
   }),
 
   senderIds: telnyxMethod({
     method: 'GET',
-    path: '/{messagingProfileId}/sender_ids',
+    path: '/{messagingProfileId}/alphanumeric_sender_ids',
     urlParams: ['messagingProfileId'],
   }),
 });

--- a/lib/resources/MessagingSenderIds.js
+++ b/lib/resources/MessagingSenderIds.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = require('../TelnyxResource').extend({
-  path: 'messaging_sender_ids',
-  includeBasic: ['list', 'retrieve', 'create', 'update','del'],
+  path: 'alphanumeric_sender_ids',
+  includeBasic: ['list', 'retrieve', 'create','del'],
 });
 

--- a/lib/resources/MessagingShortCodes.js
+++ b/lib/resources/MessagingShortCodes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = require('../TelnyxResource').extend({
-  path: 'messaging_short_codes',
+  path: 'short_codes',
   includeBasic: ['list', 'retrieve', 'update'],
 });
 

--- a/test/resources/MessagesSenderIds.spec.js
+++ b/test/resources/MessagesSenderIds.spec.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var telnyx = require('../../testUtils').getTelnyxMock();
+var expect = require('chai').expect;
+
+var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo';
+
+describe('Messages Alphanumeric Sender Ids Resource', function() {
+  const createData = {
+    text: 'Hello, World!',
+    from: '+18665552368',
+    to: [{address: '+18665552367'}],
+    messaging_profile_id: '073dd98e-0c85-496b-970f-dd3b7ae21c2se'
+  }
+
+  function responseFn(response) {
+    expect(response.data).to.include({
+      text: 'Hello, World!',
+      from: '+18665552368',
+    });
+    expect(response.data.to[0]).to.include({address: '+18665552367'});
+  }
+
+  describe('create', function() {
+    it('Sends the correct request', function() {
+      return telnyx.messages.alphanumericSenderId.create(createData)
+        .then(responseFn)
+    });
+
+    it('Sends the correct request [with specified auth]', function() {
+      return telnyx.messages.alphanumericSenderId.create(createData, TEST_AUTH_KEY)
+        .then(responseFn)
+    });
+
+    it('Sends the correct request [with specified auth in options]', function() {
+      return telnyx.messages.alphanumericSenderId.create(createData, {api_key: TEST_AUTH_KEY})
+        .then(responseFn)
+    });
+  });
+});

--- a/test/resources/MessagingPhoneNumbers.spec.js
+++ b/test/resources/MessagingPhoneNumbers.spec.js
@@ -8,7 +8,7 @@ var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo'
 describe('MessagingPhoneNumbers Resource', function() {
   describe('retrieve', function() {
     function responseFn(response) {
-      expect(response.data).to.include({id: '123', phone_number: '123', record_type: 'messaging_phone_number'});
+      expect(response.data).to.include({id: '123', record_type: 'messaging_phone_number'});
     }
 
     it('Sends the correct request', function() {
@@ -51,7 +51,6 @@ describe('MessagingPhoneNumbers Resource', function() {
         .then(function(response) {
           expect(response.data).to.include({
             id: '123',
-            phone_number: '123',
             organization_id: '3fa85f64-5717-4562-b331-2c963f66afa6',
             record_type: 'messaging_phone_number',
           });

--- a/test/resources/MessagingProfiles.spec.js
+++ b/test/resources/MessagingProfiles.spec.js
@@ -8,7 +8,7 @@ var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo'
 
 var METHODS = [
   'phone_numbers',
-  'sender_ids',
+  'alphanumeric_sender_ids',
   'short_codes',
   'del',
 ];
@@ -16,7 +16,7 @@ var METHODS = [
 describe('MessagingProfiles Resource', function() {
   describe('retrieve', function() {
     function responseFn(response) {
-      expect(response.data).to.include({id: '123', resource_group_id: '123'});
+      expect(response.data).to.include({id: '123'});
     }
 
     it('Sends the correct request', function() {
@@ -79,7 +79,6 @@ describe('MessagingProfiles Resource', function() {
     function responseFn(response) {
       expect(response.data[0]).to.have.property('id');
       expect(response.data[0]).to.have.property('name');
-      expect(response.data[0]).to.have.property('resource_group_id');
       expect(response.data[0]).to.include({record_type: 'messaging_profile'});
     }
 
@@ -113,18 +112,6 @@ describe('MessagingProfiles Resource', function() {
           .then(responseFn);
       });
     });
-
-    describe('phoneNumbers', function() {
-      it('Sends the correct request', function() {
-        telnyx.messagingProfiles.phoneNumbers('123')
-          .then(responseFn);
-      });
-
-      it('Sends the correct request [with specified auth]', function() {
-        telnyx.messagingProfiles.phoneNumbers('123', TEST_AUTH_KEY)
-          .then(responseFn);
-      });
-    });
   });
 
   describe('ShortCodes methods', function() {
@@ -132,60 +119,49 @@ describe('MessagingProfiles Resource', function() {
       expect(response.data[0]).to.have.property('id');
       expect(response.data[0]).to.have.property('short_code');
       expect(response.data[0]).to.have.property('messaging_profile_id');
-      expect(response.data[0]).to.include({record_type: 'messaging_short_code'});
+      expect(response.data[0]).to.include({record_type: 'short_code'});
     }
 
     describe('listShortCodes', function() {
       it('Sends the correct request', function() {
-        telnyx.messagingProfiles.listShortCodes('123')
+        return telnyx.messagingProfiles.listShortCodes('123')
           .then(responseFn);
       });
 
       it('Sends the correct request [with specified auth]', function() {
-        telnyx.messagingProfiles.listShortCodes('123', TEST_AUTH_KEY)
-          .then(responseFn);
-      });
-    });
-    describe('shortCodes', function() {
-      it('Sends the correct request', function() {
-        telnyx.messagingProfiles.shortCodes('123')
-          .then(responseFn);
-      });
-
-      it('Sends the correct request [with specified auth]', function() {
-        telnyx.messagingProfiles.shortCodes('123', TEST_AUTH_KEY)
+        return telnyx.messagingProfiles.listShortCodes('123', TEST_AUTH_KEY)
           .then(responseFn);
       });
     });
   });
 
-  describe('SenderIds methods', function() {
+  describe('AlphanumericSenderIds methods', function() {
     function responseFn(response) {
       expect(response.data[0]).to.have.property('id');
-      expect(response.data[0]).to.have.property('sender_id');
+      expect(response.data[0]).to.have.property('alphanumeric_sender_id');
       expect(response.data[0]).to.have.property('messaging_profile_id');
-      expect(response.data[0]).to.include({record_type: 'messaging_sender_id'});
+      expect(response.data[0]).to.include({record_type: 'alphanumeric_sender_id'});
     }
 
     describe('listSenderIds', function() {
       it('Sends the correct request', function() {
-        telnyx.messagingProfiles.listSenderIds('123')
+        return telnyx.messagingProfiles.listSenderIds('123')
           .then(responseFn);
       });
 
       it('Sends the correct request [with specified auth]', function() {
-        telnyx.messagingProfiles.listSenderIds('123', TEST_AUTH_KEY)
+        return telnyx.messagingProfiles.listSenderIds('123', TEST_AUTH_KEY)
           .then(responseFn);
       });
     });
     describe('senderIds', function() {
       it('Sends the correct request', function() {
-        telnyx.messagingProfiles.senderIds('123')
+        return telnyx.messagingProfiles.senderIds('123')
           .then(responseFn);
       });
 
       it('Sends the correct request [with specified auth]', function() {
-        telnyx.messagingProfiles.senderIds('123', TEST_AUTH_KEY)
+        return telnyx.messagingProfiles.senderIds('123', TEST_AUTH_KEY)
           .then(responseFn);
       });
     });

--- a/test/resources/MessagingSenderIds.spec.js
+++ b/test/resources/MessagingSenderIds.spec.js
@@ -5,13 +5,13 @@ var expect = require('chai').expect;
 
 var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo';
 
-describe('MessagingSenderIds Resource', function() {
+describe('Messaging AlphanumericSenderIds Resource', function() {
   describe('retrieve', function() {
     function responseFn(response) {
       expect(response.data).to.include({
         id: '123',
         messaging_profile_id: '123',
-        record_type: 'messaging_sender_id'
+        record_type: 'alphanumeric_sender_id'
       });
     }
 
@@ -32,22 +32,22 @@ describe('MessagingSenderIds Resource', function() {
 
   describe('create', function() {
     function responseFn(response) {
-      expect(response.data).to.include({sender_id: 'Summer Campaign', record_type: 'messaging_sender_id'});
+      expect(response.data).to.include({alphanumeric_sender_id: 'Summer Campaign', record_type: 'alphanumeric_sender_id'});
     }
 
     function responseFnNoBody(response) {
       expect(response.data).to.have.property('id');
-      expect(response.data).to.have.property('sender_id');
+      expect(response.data).to.have.property('alphanumeric_sender_id');
       expect(response.data).to.have.property('record_type');
     }
 
     it('Sends the correct request', function() {
-      return telnyx.messagingSenderIds.create({sender_id: 'Summer Campaign'})
+      return telnyx.messagingSenderIds.create({alphanumeric_sender_id: 'Summer Campaign'})
         .then(responseFn);
     });
 
     it('Sends the correct request [with specified auth]', function() {
-      return telnyx.messagingSenderIds.create({sender_id: 'Summer Campaign'}, TEST_AUTH_KEY)
+      return telnyx.messagingSenderIds.create({alphanumeric_sender_id: 'Summer Campaign'}, TEST_AUTH_KEY)
         .then(responseFn);
     });
 
@@ -57,7 +57,7 @@ describe('MessagingSenderIds Resource', function() {
     });
 
     it('Sends the correct request [with specified auth in options]', function() {
-      return telnyx.messagingSenderIds.create({sender_id: 'Summer Campaign'}, {api_key: TEST_AUTH_KEY})
+      return telnyx.messagingSenderIds.create({alphanumeric_sender_id: 'Summer Campaign'}, {api_key: TEST_AUTH_KEY})
         .then(responseFn);
     });
 
@@ -67,24 +67,11 @@ describe('MessagingSenderIds Resource', function() {
     });
   });
 
-  describe('update', function() {
-    it('Sends the correct request', function() {
-      return telnyx.messagingSenderIds.update('123', {messaging_profile_id: 'Foo "baz"'})
-        .then(function(response) {
-          expect(response.data).to.include({
-            id: '123',
-            messaging_profile_id: 'Foo "baz"',
-            record_type: 'messaging_sender_id'
-          });
-        });
-    });
-  });
-
   describe('del', function() {
     it('Sends the correct request', function() {
       return telnyx.messagingSenderIds.del('123')
         .then(function(response) {
-          expect(response.data).to.include({id: '123', record_type: 'messaging_sender_id'});
+          expect(response.data).to.include({id: '123', record_type: 'alphanumeric_sender_id'});
         });
     });
   });
@@ -92,8 +79,8 @@ describe('MessagingSenderIds Resource', function() {
   describe('list', function() {
     function responseFn(response) {
       expect(response.data[0]).to.have.property('id');
-      expect(response.data[0]).to.have.property('sender_id');
-      expect(response.data[0]).to.include({record_type: 'messaging_sender_id'});
+      expect(response.data[0]).to.have.property('alphanumeric_sender_id');
+      expect(response.data[0]).to.include({record_type: 'alphanumeric_sender_id'});
 
     }
 

--- a/test/resources/MessagingShortCodes.spec.js
+++ b/test/resources/MessagingShortCodes.spec.js
@@ -11,7 +11,7 @@ describe('MessagingShortCodes Resource', function() {
       expect(response.data).to.include({
         id: '123',
         messaging_profile_id: '123',
-        record_type: 'messaging_short_code'
+        record_type: 'short_code'
       });
     }
     it('Sends the correct request', function() {
@@ -32,7 +32,7 @@ describe('MessagingShortCodes Resource', function() {
           expect(response.data).to.include({
             id: '123',
             short_code: '54321',
-            record_type: 'messaging_short_code'
+            record_type: 'short_code'
           });
         })
     });
@@ -42,7 +42,7 @@ describe('MessagingShortCodes Resource', function() {
     function responseFn(response) {
       expect(response.data[0]).to.have.property('id');
       expect(response.data[0]).to.have.property('short_code');
-      expect(response.data[0]).to.include({record_type: 'messaging_short_code'});
+      expect(response.data[0]).to.include({record_type: 'short_code'});
     }
 
     it('Sends the correct request', function() {


### PR DESCRIPTION
- Messaging Sender Ids to Alphanumeric Sender Ids 
- Adjust the naming of paths for Short Codes as well.
- Add nested Alphanumeric Sender Id in [messages](https://developersdev.telnyx.com/docs/api/v2/messages)

For reference: [developer docs](https://developersdev.telnyx.com/docs/api/v2/messages) and [Telnyx-Python Update](https://github.com/team-telnyx/telnyx-python/pull/7)