### PR TITLE
Resources Empty Constructors

### DIFF
--- a/lib/TelnyxResource.js
+++ b/lib/TelnyxResource.js
@@ -40,6 +40,10 @@ function TelnyxResource(telnyx, urlData) {
     }
   }
 
+  if (this.instanceMethods) {
+    Object.assign(this, this.instanceMethods);
+  }
+
   this.initialize.apply(this, arguments);
 }
 

--- a/lib/resources/Calls.js
+++ b/lib/resources/Calls.js
@@ -47,8 +47,14 @@ module.exports = require('../TelnyxResource').extend({
         response,
         telnyx,
         'calls',
-        utils.createNestedMethods(telnyxMethod, CALL_COMMANDS, getSpec(response.data.call_control_id))
+        utils.createNestedMethods(
+          telnyxMethod,
+          CALL_COMMANDS,
+          getSpec(response.data.call_control_id)
+        )
       );
     },
   }),
+
+  instanceMethods: utils.createNestedMethods(telnyxMethod, CALL_COMMANDS, getSpec())
 });

--- a/lib/resources/Conferences.js
+++ b/lib/resources/Conferences.js
@@ -41,4 +41,6 @@ module.exports = require('../TelnyxResource').extend({
       );
     },
   }),
+
+  instanceMethods: utils.createNestedMethods(telnyxMethod, CONFERENCES, getSpec())
 });

--- a/lib/telnyx.js
+++ b/lib/telnyx.js
@@ -259,9 +259,18 @@ Telnyx.prototype = {
 
   _prepResources: function() {
     for (var name in resources) {
-      this[utils.pascalToCamelCase(name)] = new resources[name](this);
+      var camelCaseName = utils.pascalToCamelCase(name);
+
+      this[camelCaseName] = new resources[name](this);
+      this[utils.toSingular(name)] = this._createEmptyConstructor(this[camelCaseName]);
     }
   },
+
+  _createEmptyConstructor: function(content) {
+    return function() {
+      return content;
+    }
+  }
 };
 
 module.exports = Telnyx;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -229,6 +229,15 @@ var utils = module.exports = {
   },
 
   /**
+   * remove final `s` from names
+   */
+  toSingular: function(name) {
+    if (name.endsWith('s')) {
+      return name.slice(0, -1);
+    }
+  },
+
+  /**
    * Add TelnyxResource to API response data
    *
    * @param [response] Resource response object

--- a/test/resources/Calls.spec.js
+++ b/test/resources/Calls.spec.js
@@ -161,6 +161,28 @@ describe('Calls Resource', function() {
             })
         });
 
+        it('Sends the correct method request [with empty resource instance]', function() {
+          const call = new telnyx.Call();
+          call.call_control_id = '3fa85f55-5717-4562-b3fc-2c963f63vga6';
+
+          call[utils.snakeToCamelCase(command)](callCommandsData[command] || {})
+            .then(responseFn);
+
+          return call[command](callCommandsData[command] || {})
+            .then(responseFn);
+        });
+
+        it('Sends the correct method request [with empty resource instance and specified auth]', function() {
+          const call = new telnyx.Call();
+          call.call_control_id = '3fa85f55-5717-4562-b3fc-2c963f63vga6';
+
+          call[utils.snakeToCamelCase(command)](callCommandsData[command] || {}, TEST_AUTH_KEY)
+            .then(responseFn);
+
+          return call[command](callCommandsData[command] || {}, TEST_AUTH_KEY)
+            .then(responseFn);
+        });
+
         if (camelCaseCommand !== command) {
           describe(camelCaseCommand, function() {
             it('Sends the correct request', function() {

--- a/test/resources/Conferences.spec.js
+++ b/test/resources/Conferences.spec.js
@@ -84,6 +84,21 @@ describe('Calls Resource', function() {
                 .then(responseFn);
             })
         });
+
+        it('Sends the correct request [with empty resource instance]', function() {
+          const conference = new telnyx.Conference();
+          conference.call_control_id = '891510ac-f3e4-11e8-af5b-de00688a4901';
+
+          return conference[action](callConferencesData[action] || {})
+            .then(responseFn);
+        });
+        it('Sends the correct request [with empty resource instance and specified auth]', function() {
+          const conference = new telnyx.Conference();
+          conference.call_control_id = '891510ac-f3e4-11e8-af5b-de00688a4901';
+
+          return conference[action](callConferencesData[action] || {}, TEST_AUTH_KEY)
+            .then(responseFn);
+        });
       });
     });
   });


### PR DESCRIPTION
Allow Resources instances to be returned using empty constructors that correspond to the resource name, `PascalCased` and in the singular form. 

Ex: `telnyx.calls` resource can create a new empty call object by calling `new telnyx.Call()`. This allows users to populate empty calls and conferences resources and then execute nested methods, as in [this example](https://github.com/team-telnyx/api-v2-sdk-testing/blob/master/ruby/receive_webhooks.rb#L21)