### PR TITLE
replace c compiled ed25519 package with native one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "8"
   - "9"
   - "10"
+  - "12"
 sudo: false
 
 cache:

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Buffer = require('safe-buffer').Buffer;
-var ed25519 = require('ed25519');
+var nacl = require('tweetnacl');
 
 var Error = require('./Error');
 
@@ -23,13 +23,11 @@ var signature = {
 
     var payloadBuffer = Buffer.from(`${timestampHeader}|${payload}`, 'utf8');
 
-    // eslint-disable-next-line new-cap
-    var keyPair = ed25519.MakeKeypair(Buffer.from(publicKey, 'base64'));
+    var keyPair = nacl.sign.keyPair.fromSeed(Buffer.from(publicKey, 'base64'));
     var verification;
 
     try {
-      // eslint-disable-next-line new-cap
-      verification = ed25519.Verify(payloadBuffer, signatureHeader, keyPair.publicKey);
+      verification = nacl.sign.detached.verify(payloadBuffer, signatureHeader, keyPair.publicKey);
     } catch (err) {
       throwSignatureVerificationError(payload, signatureHeader, timestampHeader);
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -289,14 +289,14 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
-      }
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -692,15 +692,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "ed25519": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ed25519/-/ed25519-0.0.4.tgz",
-      "integrity": "sha1-5WIYrOL8kD0llZOu8LKpY59HW+s=",
-      "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.0.9"
-      }
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -936,11 +927,6 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-cache-dir": {
       "version": "2.1.0",
@@ -1675,11 +1661,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2327,6 +2308,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
+        }
       }
     },
     "string-width": {
@@ -2504,10 +2493,9 @@
       }
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
-    "ed25519": "0.0.4",
     "lodash.isplainobject": "^4.0.6",
     "qs": "^6.6.0",
     "safe-buffer": "^5.1.1",
+    "tweetnacl": "^1.0.1",
     "uuid": "^3.3.2"
   },
   "license": "MIT",

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -4,7 +4,7 @@ var telnyx = require('../testUtils').getSpyableTelnyx();
 var expect = require('chai').expect;
 var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
-var ed25519 = require('ed25519');
+var nacl = require('tweetnacl');
 
 var EVENT_PAYLOAD = {
   data: {
@@ -144,6 +144,5 @@ function generateSignature(opts) {
 
   var payload = Buffer.from(`${opts.timestamp}|${opts.payload}`, 'utf8');
 
-  // eslint-disable-next-line new-cap
-  return ed25519.Sign(payload, ed25519.MakeKeypair(Buffer.from(PUBLIC_KEY, 'base64')));
+  return nacl.sign.detached(payload, nacl.sign.keyPair.fromSeed(Buffer.from(PUBLIC_KEY, 'base64')).secretKey);
 }


### PR DESCRIPTION
[tweetnacl-js](https://github.com/dchest/tweetnacl-js) translates the original TweetNaCl implementation to JS, including ed25519 implementation

`ed25519` package didn't work with node v12. Context: https://telnyx.slack.com/archives/C7DJWC8NM/p1567640998002100 and https://telnyx.slack.com/archives/C7DJWC8NM/p1567641084003200

Issue: #7 