### PR TITLE
use arrayFormat of brackets

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ var utils = module.exports = {
    * (forming the conventional key 'parent[child]=value')
    */
   stringifyRequestData: function(data) {
-    return qs.stringify(data)
+    return qs.stringify(data, {arrayFormat: 'brackets'})
       // Don't use strict form encoding by changing the square bracket control
       // characters back to their literals. This is fine by the server, and
       // makes these parameter strings easier to read.

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -51,7 +51,7 @@ describe('utils', function() {
           {b: 'c'},
           {b: 'd'},
         ],
-      })).to.equal('a[0][b]=c&a[1][b]=d');
+      })).to.equal('a[][b]=c&a[][b]=d');
     })
 
     it('Handles indexed arrays', function() {


### PR DESCRIPTION
As per https://www.npmjs.com/package/qs, `{arrayFormat: 'brackets'}` will achieve the query parameter array format specified in the documentation for curl https://developers.telnyx.com/docs/api/v2/numbers/Number-Search?lang=curl#listAvailablePhoneNumbers