### PR TITLE
fix(resources): outdated specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 env:
   global:
     # If changing this number, please also look it at tests config.
-    - TELNYX_MOCK_VERSION=0.8.8
+    - TELNYX_MOCK_VERSION=0.8.10
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/test/resources/Messages.spec.js
+++ b/test/resources/Messages.spec.js
@@ -32,10 +32,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       })
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368',
-          });
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });
@@ -47,10 +45,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       }, TEST_AUTH_KEY)
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368'
-          });
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });
@@ -62,9 +58,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       }, {api_key: TEST_AUTH_KEY})
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368'});
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });

--- a/test/resources/NumberOrders.spec.js
+++ b/test/resources/NumberOrders.spec.js
@@ -31,8 +31,8 @@ describe('NumberOrders Resource', function() {
       expect(response.data[0]).to.have.property('id');
       expect(response.data[0]).to.have.property('status');
       expect(response.data[0]).to.have.property('customer_reference');
-      expect(response.data[0]).to.have.property('connection_id');
-      expect(response.data[0]).to.have.property('messaging_profile_id');
+      expect(response.data[0]).to.have.property('requirements_met');
+      expect(response.data[0]).to.have.property('phone_numbers_count');
       expect(response.data[0]).to.include({record_type: 'number_order'});
     }
 
@@ -63,14 +63,16 @@ describe('NumberOrders Resource', function() {
   describe('create', function() {
     function responseFn(response) {
       expect(response.data).to.include({
-        connection_id: '442191469269222625',
         record_type: 'number_order',
       });
+      expect(response.data).to.have.property('requirements_met');
+      expect(response.data).to.have.property('phone_numbers_count');
     }
 
     function responseFnNoBody(response) {
       expect(response.data).to.have.property('id');
-      expect(response.data).to.have.property('connection_id');
+      expect(response.data).to.have.property('requirements_met');
+      expect(response.data).to.have.property('phone_numbers_count');
       expect(response.data).to.include({record_type: 'number_order'});
     }
 

--- a/test/resources/SimCards.spec.js
+++ b/test/resources/SimCards.spec.js
@@ -9,8 +9,8 @@ var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo'
 describe('SimCards Resource', function() {
   describe('retrieve', function() {
     function responseFn(response) {
+      expect(response.data).to.have.property('id');
       expect(response.data).to.include({
-        id: '123',
         record_type: 'sim_card'
       });
     }


### PR DESCRIPTION
Update 

- Number Orders Outdated specs on `connection_id` and `messaging_profile_id`
- Messages Outdated specs on `from` format (`carrier`, `line_type` and `phone_number`)
- SIM Cards unreal specs