### PR TITLE
feat(resources): OTA Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 env:
   global:
     # If changing this number, please also look it at tests config.
-    - TELNYX_MOCK_VERSION=0.8.8
+    - TELNYX_MOCK_VERSION=0.8.10
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/lib/resources/OtaUpdates.js
+++ b/lib/resources/OtaUpdates.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var TelnyxResource = require('../TelnyxResource');
+
+module.exports = TelnyxResource.extend({
+  path: 'ota_updates',
+
+  includeBasic: ['list', 'retrieve'],
+});

--- a/lib/telnyx.js
+++ b/lib/telnyx.js
@@ -61,7 +61,8 @@ var resources = {
   Actions: require('./resources/Actions'),
   OutboundVoiceProfiles: require('./resources/Outbound'),
   CallControlApplications: require('./resources/CallControlApplications'),
-  PhoneNumbersInboundChannels: require('./resources/PhoneNumbersInboundChannels')
+  PhoneNumbersInboundChannels: require('./resources/PhoneNumbersInboundChannels'),
+  OtaUpdates: require('./resources/OtaUpdates')
 };
 
 Telnyx.TelnyxResource = require('./TelnyxResource');

--- a/test/resources/Messages.spec.js
+++ b/test/resources/Messages.spec.js
@@ -32,10 +32,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       })
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368',
-          });
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });
@@ -47,10 +45,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       }, TEST_AUTH_KEY)
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368'
-          });
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });
@@ -62,9 +58,8 @@ describe('Messages Resource', function() {
         to: [{address: '+18665552367'}],
       }, {api_key: TEST_AUTH_KEY})
         .then(function(response) {
-          expect(response.data).to.include({
-            text: 'Hello, World!',
-            from: '+18665552368'});
+          expect(response.data).to.include.keys(['from', 'text']);
+          expect(response.data.from).to.include.keys(['carrier', 'line_type', 'phone_number']);
           expect(response.data.to[0]).to.include({address: '+18665552367'});
         })
     });

--- a/test/resources/NumberOrders.spec.js
+++ b/test/resources/NumberOrders.spec.js
@@ -31,8 +31,8 @@ describe('NumberOrders Resource', function() {
       expect(response.data[0]).to.have.property('id');
       expect(response.data[0]).to.have.property('status');
       expect(response.data[0]).to.have.property('customer_reference');
-      expect(response.data[0]).to.have.property('connection_id');
-      expect(response.data[0]).to.have.property('messaging_profile_id');
+      expect(response.data[0]).to.have.property('requirements_met');
+      expect(response.data[0]).to.have.property('phone_numbers_count');
       expect(response.data[0]).to.include({record_type: 'number_order'});
     }
 
@@ -63,14 +63,16 @@ describe('NumberOrders Resource', function() {
   describe('create', function() {
     function responseFn(response) {
       expect(response.data).to.include({
-        connection_id: '442191469269222625',
         record_type: 'number_order',
       });
+      expect(response.data).to.have.property('requirements_met');
+      expect(response.data).to.have.property('phone_numbers_count');
     }
 
     function responseFnNoBody(response) {
       expect(response.data).to.have.property('id');
-      expect(response.data).to.have.property('connection_id');
+      expect(response.data).to.have.property('requirements_met');
+      expect(response.data).to.have.property('phone_numbers_count');
       expect(response.data).to.include({record_type: 'number_order'});
     }
 

--- a/test/resources/OtaUpdates.spec.js
+++ b/test/resources/OtaUpdates.spec.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var utils = require('../../testUtils');
+var telnyx = utils.getTelnyxMock();
+var expect = require('chai').expect;
+
+var TEST_AUTH_KEY = utils.getUserTelnyxKey();
+
+describe('OtaUpdates Resource', function() {
+  describe.skip('retrieve', function() {
+    function responseFn(response) {
+      expect(response.data).to.include.keys(['id', 'sim_card_id', 'status', 'settings']);
+      expect(response.data).to.include({
+        record_type: 'ota_update',
+        type: 'sim_card_network_preferences'
+      });
+    }
+
+    it('Sends the correct request', function() {
+      return telnyx.otaUpdates.retrieve('123')
+        .then(responseFn);
+    });
+
+    it('Sends the correct request [with specified auth]', function() {
+      return telnyx.otaUpdates.retrieve('123', TEST_AUTH_KEY)
+        .then(responseFn);
+    });
+  });
+
+  describe('list', function() {
+    function responseFn(response) {
+      expect(response.data[0]).to.include.keys(['id', 'sim_card_id', 'status']);
+      expect(response.data[0]).to.include({
+        record_type: 'ota_update',
+        type: 'sim_card_network_preferences'
+      });
+    }
+
+    it('Sends the correct request', function() {
+      return telnyx.otaUpdates.list()
+        .then(responseFn);
+    });
+
+    it('Sends the correct request [with specified auth]', function() {
+      return telnyx.otaUpdates.list(TEST_AUTH_KEY)
+        .then(responseFn);
+    });
+  });
+});

--- a/test/resources/SimCards.spec.js
+++ b/test/resources/SimCards.spec.js
@@ -9,8 +9,8 @@ var TEST_AUTH_KEY = 'KEY187557EC22404DB39975C43ACE661A58_9QdDI7XD5bvyahtaWx1YQo'
 describe('SimCards Resource', function() {
   describe('retrieve', function() {
     function responseFn(response) {
+      expect(response.data).to.have.property('id');
       expect(response.data).to.include({
-        id: '123',
         record_type: 'sim_card'
       });
     }


### PR DESCRIPTION
https://developers.telnyx.com/docs/api/v2/wireless/OTA-updates

retrieve OTA Updates by id specs are disabled while `telnyx-mock` is failing to parse the specs. Context:

```
In property 'settings' of object:
Schema is an object:
{
  "example": {
    "mobile_operator_networks_preferences": [
      {
        "mobile_operator_network_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58",
        "mobile_operator_network_name": "AT\u0026T Mobility (USACG)",
        "priority": 0
      }
    ]
  },
  "properties": {
    "mobile_operator_networks_preferences": {
      "$ref": "#/components/schemas/MobileOperatorNetworksPreferencesResponse"
    }
  },
  "type": "object"
}

But example is (type: json.RawMessage):
{
  "mobile_operator_networks_preferences": [
    {
      "mobile_operator_network_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58",
      "mobile_operator_network_name": "AT&T Mobility (USACG)",
      "priority": 0
    }
  ]
}
```