### PR TITLE
fix(resources): reinstantiate Resources on Constructor Call

### DIFF
--- a/examples/webhook-signing/call-control/index.js
+++ b/examples/webhook-signing/call-control/index.js
@@ -11,4 +11,8 @@ const apiKey = process.env.TELNYX_API_KEY;
 
 const telnyx = Telnyx(apiKey);
 
-telnyx.calls.create({connection_id: 'uuid', to: '+1111111111111', from: '+1111111111111'});
+try {
+  telnyx.calls.create({connection_id: 'uuid', to: '+1111111111111', from: '+1111111111111'});
+} catch (e) {
+  console.error(e);
+}

--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -59,7 +59,17 @@ app.post('/webhooks', bodyParser.json(), function(req, res) {
 
     const call = new telnyx.Call({call_control_id: event.data.payload.call_control_id});
 
-    call.gather_using_audio({audio_url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'});
+    call.gather_using_audio({audio_url: 'https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3'});
+  }
+  if (event.data.event_type === 'call.gather.ended') {
+    console.log('Call Gathered with Audio. Hanging up call control id: ' + event.data.payload.call_control_id);
+
+    const call = new telnyx.Call({call_control_id: event.data.payload.call_control_id});
+
+    call.hangup();
+  }
+  if (event.data.event_type === 'call.hangup') {
+    console.log('Call Hangup. call control id: ' + event.data.payload.call_control_id);
   }
 
   // Event was 'constructed', so we can respond with a 200 OK

--- a/lib/telnyx.js
+++ b/lib/telnyx.js
@@ -284,18 +284,25 @@ Telnyx.prototype = {
 
   _prepResources: function() {
     for (var name in resources) {
-      var camelCaseName = utils.pascalToCamelCase(name);
+      this._instantiateResource(name, this);
 
-      this[camelCaseName] = new resources[name](this);
-      this[utils.toSingular(name)] = this._createEmptyConstructor(this[camelCaseName]);
+      this[utils.toSingular(name)] = this._createConstructor(name, this);
     }
   },
 
-  _createEmptyConstructor: function(content) {
+  _instantiateResource: function(name, self) {
+    var camelCaseName = utils.pascalToCamelCase(name);
+
+    self[camelCaseName] = new resources[name](self);
+
+    return self[camelCaseName];
+  },
+
+  _createConstructor: function(resourceName, self) {
     return function(args) {
-      return Object.assign(content, args || {});
+      return Object.assign(self._instantiateResource(resourceName, self), args || {});
     }
-  }
+  },
 };
 
 module.exports = Telnyx;

--- a/test/resources/Calls.spec.js
+++ b/test/resources/Calls.spec.js
@@ -119,7 +119,7 @@ describe('Calls Resource', function() {
         expect(response.data).to.have.property('call_session_id');
         expect(response.data).to.have.property('call_leg_id');
         expect(response.data).to.have.property('call_control_id');
-        expect(response.data).to.include({record_type: 'call', is_alive: true});
+        expect(response.data).to.include({record_type: 'call', is_alive: false});
       }
 
       it('Sends the correct request', function() {


### PR DESCRIPTION
To fix #26 new issues when having a subsequent call flow situation.

Update specs as `is_alive` defaults to `false` now

To test, you may set up a [CC App](https://developersdev.telnyx.com/docs/v2/call-control/quickstart), checkout the branch and then run:

1. Run the `examples/webhook-signing/express.js` file by:
   - Modifying the telnyx import to be relative to the local lib with the fixes: `const Telnyx = require('../../lib/telnyx');`
   - passing your dev/prod `TELNYX_API_KEY` and your `TELNYX_PUBLIC_KEY`: TELNYX_API_KEY=KEYXXXX TELNYX_PUBLIC_KEY=XXXX TELNYX_API_BASE=api.telnyx.com node ./examples/webhook-signing/express.js

2. Expose the server running at port 3000 to public using ngrok `./ngrok http 3000` and set the ngrok address to your call control application assigned to the `to` number (inbound call flow)
3. Run the call-control example to initiate a call 
   - TELNYX_API_KEY=KEYXXXX TELNYX_API_BASE=api.telnyx.com node ./examples/call-control/index.js
4. See in the server console the call statuses. You should be able to repeat this flow without seeing any `Call has already ended` error

```
Call Initiated. Answering call with call control id: v2:IlpmC-TmuBLCs7q-uTROUUjjQFI77vP6TFxWzhHJauRL_HyJjlWAVw
Call Answered. Gather audio with the call control id: v2:IlpmC-TmuBLCs7q-uTROUUjjQFI77vP6TFxWzhHJauRL_HyJjlWAVw
Call Gathered with Audio. Hanging up call control id: v2:IlpmC-TmuBLCs7q-uTROUUjjQFI77vP6TFxWzhHJauRL_HyJjlWAVw
Call Hangup. call control id: v2:IlpmC-TmuBLCs7q-uTROUUjjQFI77vP6TFxWzhHJauRL_HyJjlWAVw

Call Initiated. Answering call with call control id: v2:dFQRZI6D9KLuWGjgJm0iii1_SE39P1VtL7d6n0Fj5FJX69V5k_5LWA
Call Answered. Gather audio with the call control id: v2:dFQRZI6D9KLuWGjgJm0iii1_SE39P1VtL7d6n0Fj5FJX69V5k_5LWA
Call Gathered with Audio. Hanging up call control id: v2:dFQRZI6D9KLuWGjgJm0iii1_SE39P1VtL7d6n0Fj5FJX69V5k_5LWA
Call Hangup. call control id: v2:dFQRZI6D9KLuWGjgJm0iii1_SE39P1VtL7d6n0Fj5FJX69V5k_5LWA
```
 