### PR TITLE
feat(WEBRTC-215): add ondemand credential resource

### DIFF
--- a/lib/TelnyxResource.js
+++ b/lib/TelnyxResource.js
@@ -147,7 +147,7 @@ TelnyxResource.prototype = {
         self._telnyx._emitter.emit('response', responseEvent);
 
         try {
-          response = JSON.parse(response);
+          response = utils.tryParseJSON(response);
 
           if (response.errors) {
             var error = {};

--- a/lib/resources/TelephonyCredentials.js
+++ b/lib/resources/TelephonyCredentials.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var TelnyxResource = require('../TelnyxResource');
+var utils = require('../utils');
+var telnyxMethod = TelnyxResource.method;
+
+function transformResponseData(response, telnyx) {
+  return utils.addResourceToResponseData(
+    response,
+    telnyx,
+    'telephonyCredentials'
+  );
+}
+
+module.exports = TelnyxResource.extend({
+  path: 'telephony_credentials',
+
+  create: telnyxMethod({
+    method: 'POST',
+
+    transformResponseData: transformResponseData,
+  }),
+
+  retrieve: telnyxMethod({
+    method: 'POST',
+    path: '/{id}/token',
+    urlParams: ['id'],
+
+    transformResponseData: transformResponseData,
+  }),
+});

--- a/lib/telnyx.js
+++ b/lib/telnyx.js
@@ -71,6 +71,7 @@ var resources = {
   Faxes: require('./resources/Faxes'),
   ShortCodes: require('./resources/ShortCodes'),
   MessagingProfileMetrics: require('./resources/MessagingProfileMetrics'),
+  TelephonyCredentials: require('./resources/TelephonyCredentials'),
 };
 
 Telnyx.TelnyxResource = require('./TelnyxResource');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -245,20 +245,24 @@ var utils = module.exports = {
    * @param [resourceName] Resource name in camelCase
    * @param [methods] resource methods to include
    */
-  addResourceToResponseData: function(response, telnyx, resourceName, methods) {
+  addResourceToResponseData: function (
+    response,
+    telnyx,
+    resourceName,
+    methods
+  ) {
+    if (response && response.data && typeof response.data === 'object') {
 
-    /*
-      * make nested methods. e.g.: call.bridge();
-      * nested methods should be used from basic methods response. See specs for an example
-      */
-    var resourceFulData = telnyx[resourceName];
+      /*
+       * make nested methods. e.g.: call.bridge();
+       * nested methods should be used from basic methods response. See specs for an example
+       */
+      var resourceFulData = telnyx[resourceName];
 
-    Object.assign(
-      resourceFulData,
-      response.data,
-      methods
-    );
-    response.data = resourceFulData;
+      Object.assign(resourceFulData, response.data, methods);
+
+      response.data = resourceFulData;
+    }
 
     return response;
   },
@@ -281,6 +285,8 @@ var utils = module.exports = {
   },
 
   emitWarning: emitWarning,
+
+  tryParseJSON: tryParseJSON,
 };
 
 function emitWarning(warning) {
@@ -289,4 +295,22 @@ function emitWarning(warning) {
   }
 
   return process.emitWarning(warning, 'Telnyx');
+}
+
+/**
+ * tryParseJSON used to only parse JSON response,
+ * if it is not a JSON response sends the value inside a data object to keep the standard.
+ *
+ * @param [jsonString]  Response object
+ */
+function tryParseJSON (jsonString) {
+  try {
+    return JSON.parse(jsonString);
+  } catch (e) {
+    const defaultValue = {
+      data: jsonString
+    };
+
+    return defaultValue;
+  }
 }

--- a/test/resources/TelephonyCredentials.spec.js
+++ b/test/resources/TelephonyCredentials.spec.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var utils = require('../../testUtils');
+var telnyx = utils.getTelnyxMock();
+var expect = require('chai').expect;
+
+var TEST_AUTH_KEY = utils.getUserTelnyxKey();
+
+var credentialCreateData = {
+  credential: {
+    connection_id: '1474011037387720344',
+  },
+};
+
+describe('TelephonyCredentials Resource', function () {
+  describe('create', function () {
+    function responseFn(response) {
+      expect(response.data).to.have.property('created_at');
+      expect(response.data).to.have.property('expired');
+      expect(response.data).to.have.property('expires_at');
+      expect(response.data).to.have.property('id');
+      expect(response.data).to.have.property('name');
+      expect(response.data).to.have.property('record_type');
+      expect(response.data).to.have.property('resource_id');
+      expect(response.data).to.have.property('sip_password');
+      expect(response.data).to.have.property('sip_username');
+    }
+
+    it('Sends the correct request', function () {
+      return telnyx.telephonyCredentials.create(credentialCreateData).then(responseFn);
+    });
+
+    it('Sends the correct request [with specified auth]', function () {
+      return telnyx.telephonyCredentials.create(credentialCreateData, TEST_AUTH_KEY).then(responseFn);
+    });
+
+    it('Sends the correct request [with specified auth in options]', function () {
+      return telnyx.telephonyCredentials
+        .create(credentialCreateData, {api_key: TEST_AUTH_KEY})
+        .then(responseFn);
+    });
+  });
+
+  describe('retrieve', function () {
+    function responseFn(response) {
+      expect(response.data).to.not.be.null
+    }
+
+    it('Sends the correct request', function () {
+      return telnyx.telephonyCredentials.retrieve('9fb9e45f-958a-4d9f-81ff-735ffbcaa133').then(responseFn);
+    });
+
+    it('Sends the correct request [with specified auth]', function () {
+      return telnyx.telephonyCredentials.retrieve('9fb9e45f-958a-4d9f-81ff-735ffbcaa133', TEST_AUTH_KEY).then(responseFn);
+    });
+  });
+});


### PR DESCRIPTION
[WEBRTC-215](https://telnyx.atlassian.net/browse/WEBRTC-215)

Added new endpoints inside SDK Node to expose the telephony_credentials paths.
 - https://api.telnyx.com/v2/telephony_credentials
 - https://api.telnyx.com/v2/telephony_credentials/{id}/token

To run the tests correctly you will need to  add the prop `street_address: '311 W Superior Street'` on test/resources/Addresses.spec.js at line 21.

Notes: 

Before merge on master wait for PR #48 be approve.