### PR TITLE
HOTFIX: add prop street_address to fix the Addresses.spec

### DIFF
--- a/test/resources/Addresses.spec.js
+++ b/test/resources/Addresses.spec.js
@@ -18,6 +18,7 @@ var addressData = {
   last_name: 'Foster',
   locality: 'Chicago',
   postal_code: '2904',
+  street_address: '311 W Superior Street'
 };
 
 describe('Addresses Resource', function () {


### PR DESCRIPTION
The tests were failing because the Address.spec was missing the prop **street_address**.

Steps:
1 - Run the command `npm run test` and check if everything is green. 