### PR TITLE
refresh fax [wip]

### DIFF
--- a/lib/resources/Faxes.js
+++ b/lib/resources/Faxes.js
@@ -50,4 +50,12 @@ module.exports = TelnyxResource.extend({
 
     transformResponseData: transformResponseData,
   }),
+
+  refresh: telnyxMethod({
+    method: 'POST',
+    path: '/{id}/actions/refresh',
+    urlParams: ['id'],
+
+    transformResponseData: transformResponseData,
+  }),
 });

--- a/test/resources/Faxes.spec.js
+++ b/test/resources/Faxes.spec.js
@@ -22,6 +22,16 @@ describe('Faxes Resource', function () {
     expect(response.data).to.have.property('to');
   }
 
+  describe('list', function () {
+    function listResponseFn(response) {
+      return responseFn({data: response.data[0]})
+    }
+
+    it('Sends the correct request', function () {
+      return telnyx.faxes.list().then(listResponseFn);
+    });
+  });
+
   describe('retrieve', function () {
     it('Sends the correct request', function () {
       return telnyx.faxes.retrieve(TEST_UUID).then(responseFn);
@@ -68,17 +78,13 @@ describe('Faxes Resource', function () {
     });
   });
 
-  describe('list', function () {
-    function listResponseFn(response) {
-      return responseFn({data: response.data[0]});
+  describe.skip('refresh', function () {
+    function responseFn(response) {
+      expect(response.data).to.include({result: 'ok'});
     }
 
     it('Sends the correct request', function () {
-      return telnyx.faxes.list().then(listResponseFn);
-    });
-
-    it('Sends the correct request [with specified auth]', function () {
-      return telnyx.faxes.list(TEST_AUTH_KEY).then(listResponseFn);
+      return telnyx.faxes.refresh('123').then(responseFn);
     });
   });
 
@@ -96,6 +102,7 @@ describe('Faxes Resource', function () {
             return fax.del().then(responseFn);
           });
       });
+
       it('Sends the correct request [with specified auth]', function () {
         return telnyx.faxes.retrieve(TEST_UUID).then(function (response) {
           const fax = response.data;


### PR DESCRIPTION
refactored spec, [added refresh method](https://developers.telnyx.com/docs/api/v2/programmable-fax/Programmable-Fax-Commands#RefreshFax), skipping endpoints breaking on telnyx-mock