### PR TITLE
Calls.js: support the `streaming_start` and `streaming_stop` commands

### DIFF
--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -92,7 +92,7 @@ app.post('/texml', bodyParser.text({type: '*/*'}), function(req, res) {
       timeToleranceInSeconds
     );
   } catch (e) {
-    console.log("Failed to validate the signature")
+    console.log('Failed to validate the signature')
     console.log(e.message);
     res.send(400);
     return;

--- a/lib/resources/Calls.js
+++ b/lib/resources/Calls.js
@@ -27,7 +27,9 @@ var CALL_COMMANDS = [
   'transcription_start',
   'transcription_stop',
   'enqueue',
-  'leave_queue'
+  'leave_queue',
+  'streaming_start',
+  'streaming_stop'
 ];
 
 function getSpec(callControlId) {

--- a/test/resources/Calls.spec.js
+++ b/test/resources/Calls.spec.js
@@ -29,7 +29,9 @@ var COMMANDS = [
   'transcription_start',
   'transcription_stop',
   'enqueue',
-  'leave_queue'
+  'leave_queue',
+  'streaming_start',
+  'streaming_stop'
 ];
 
 describe('Calls Resource', function() {


### PR DESCRIPTION
This PR resolves issue:

- https://github.com/team-telnyx/telnyx-node/issues/139

Changeset:
1. Added `streaming_start` and `streaming_stop` in `Calls.js` and `Calls.spec.js`
2. Ran `npm run lint -- --fix` to fix `express.js`