### PR TITLE
Fix brand and campaign routes that need to go to /10dlc instead of /v2

### DIFF
--- a/lib/resources/Brands.js
+++ b/lib/resources/Brands.js
@@ -4,8 +4,9 @@ const TelnyxResource = require('../TelnyxResource');
 const telnyxMethod = TelnyxResource.method;
 
 module.exports = TelnyxResource.extend({
-  path: 'brands',
-  includeBasic: ['list','retrieve','update','delete'],
+  path: 'brand',
+  basePath: '/10dlc/',
+  includeBasic: ['create', 'list','retrieve','update','delete'],
 
   ListExternalVettings: telnyxMethod({
     method: 'GET',

--- a/lib/resources/CampaignBuilder.js
+++ b/lib/resources/CampaignBuilder.js
@@ -26,6 +26,7 @@ function transformResponseData(response, telnyx) {
 
 module.exports = TelnyxResource.extend({
   path: '/campaignBuilder',
+  basePath: '/10dlc/',
   create: telnyxMethod({
     method: 'POST',
     transformResponseData: transformResponseData,


### PR DESCRIPTION
Fix brand and campaign routes that need to go to /10dlc instead of /v2. Also add create method for brands which was missing.

This seems to be already present in other language SDKs such as PHP and Ruby, but was missing from JS/Node.