### PR TITLE
use correct path for basic calls

### DIFF
--- a/lib/resources/CallRecordings.js
+++ b/lib/resources/CallRecordings.js
@@ -5,7 +5,7 @@ const telnyxMethod = TelnyxResource.method;
 
 module.exports = TelnyxResource.extend({
   path: 'recordings',
-  includeBasic: ['list', 'retrieve', 'delete'],
+  includeBasic: ['list', 'retrieve', 'del'],
 
   GetRecordings: telnyxMethod({
     method: 'GET',

--- a/lib/resources/CallRecordings.js
+++ b/lib/resources/CallRecordings.js
@@ -4,8 +4,8 @@ const TelnyxResource = require('../TelnyxResource');
 const telnyxMethod = TelnyxResource.method;
 
 module.exports = TelnyxResource.extend({
-  path: 'call_recordings',
-  includeBasic: ['list','retrieve','delete'],
+  path: 'recordings',
+  includeBasic: ['list', 'retrieve', 'delete'],
 
   GetRecordings: telnyxMethod({
     method: 'GET',


### PR DESCRIPTION
Without this change, a call of `telnyx.callRecordings.list()` will result in a `404: Resource not found` since it'll attempt this request: `{ method: 'GET', path: '/v2/call_recordings/recordings' }`.

Additionally, the inclusion for basic `DELETE` support wasn't correct (was misnamed).