### PR TITLE
feat: add self-hosted release-please with two-phase trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,8 +21,8 @@ name: Release Please
 on:
   push:
     branches:
-      - next      # Phase 1: create release PR
-      - master    # Phase 2: create GitHub release + tag
+      - next # Phase 1: create release PR
+      - master # Phase 2: create GitHub release + tag
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,134 @@
+name: Release Please
+
+# Self-hosted release-please for team-telnyx/telnyx-node.
+#
+# Two-phase trigger:
+#   1. Push to `next` → create/update release PR targeting `master`
+#   2. Push to `master` (release PR merged) → create GitHub release + tag
+#
+# The promote-to-prod workflow pushes generated SDK code to the `next` branch
+# with a `Release-As: X.Y.Z` footer. This workflow runs release-please when
+# `next` receives new commits, which:
+#   1. Reads the Release-As version from the commit footer
+#   2. Opens a release PR targeting `master` with --release-as
+#   3. On merge, push to `master` triggers this workflow again
+#   4. github-release creates vX.Y.Z tag and GitHub Release
+#   5. publish-npm.yml picks up the release event and publishes to npm
+#
+# Uses the official Google release-please from npm (not the Stainless fork,
+# which has broken TypeScript compilation on newer Node versions).
+
+on:
+  push:
+    branches:
+      - next      # Phase 1: create release PR
+      - master    # Phase 2: create GitHub release + tag
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    if: github.repository == 'team-telnyx/telnyx-node'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SDK_WRITE_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install release-please
+        run: npm install release-please@17
+
+      - name: Read Release-As version from next branch
+        if: github.ref == 'refs/heads/next'
+        id: version
+        run: |
+          VERSION=""
+          # The promote-to-prod workflow injects a "Release-As: X.Y.Z" footer
+          # into the promote commit. Find the latest one in next history.
+          for commit in $(git rev-list HEAD --max-count=50); do
+            BODY=$(git log -1 --format=%b "$commit")
+            RA=$(echo "$BODY" | grep -oP 'Release-As:\s*\K[\d.]+' || true)
+            if [ -n "$RA" ]; then
+              VERSION="$RA"
+              break
+            fi
+          done
+
+          if [ -z "$VERSION" ]; then
+            echo "::warning::No Release-As found; release-please will use semantic versioning"
+            echo "has_version=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "has_version=true" >> "$GITHUB_OUTPUT"
+            echo "Release-As version: $VERSION"
+          fi
+
+      - name: Run release-please (release-pr)
+        if: github.ref == 'refs/heads/next'
+        id: release-pr
+        run: |
+          ARGS=(
+            release-pr
+            --repo-url "${{ github.repositoryUrl }}"
+            --token "${{ secrets.SDK_WRITE_TOKEN }}"
+            --target-branch master
+            --config-file release-please-config.json
+            --manifest-file .release-please-manifest.json
+          )
+
+          if [ "${{ steps.version.outputs.has_version }}" = "true" ]; then
+            ARGS+=(--release-as "${{ steps.version.outputs.version }}")
+          fi
+
+          OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
+          echo "$OUTPUT"
+
+          # Parse PR number from output if a PR was created
+          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' | head -1)
+          if [ -n "$PR_URL" ]; then
+            PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
+            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "prs_created=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prs_created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run release-please (github-release)
+        if: github.ref == 'refs/heads/master'
+        run: |
+          npx release-please github-release \
+            --repo-url "${{ github.repositoryUrl }}" \
+            --token "${{ secrets.SDK_WRITE_TOKEN }}" \
+            --target-branch master \
+            --config-file release-please-config.json \
+            --manifest-file .release-please-manifest.json \
+            2>&1 || true
+
+      - name: Enable auto-merge on release PRs
+        if: github.ref == 'refs/heads/next' && steps.release-pr.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
+        run: |
+          if [ -n "$PR_NUM" ]; then
+            gh pr merge "$PR_NUM" --auto --merge --repo "$REPO" 2>/dev/null || echo "Auto-merge already enabled or PR #$PR_NUM not mergeable"
+          fi
+          sleep 3
+          # Fallback: enable auto-merge on any open release PRs
+          prs=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number --jq '.[].number')
+          for pr in $prs; do
+            gh pr merge "$pr" --auto --merge --repo "$REPO" 2>/dev/null || true
+          done

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,9 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",


### PR DESCRIPTION
Adds release-please.yml using official Google release-please@17 from npm (not the Stainless fork).

Two-phase trigger (same pattern as Java PR #171):
- Push to `next` → create release PR targeting `master`
- Push to `master` → create GitHub release + tag → triggers `publish-npm.yml`

Fixes `release-please-config.json`:
- Switch schema from `stainless-api` to `googleapis`
- Remove `prerelease: true` and `versioning: prerelease`
- Keep MCP server extra-files

Part of TypeScript SDK cutover from Stainless SaaS mirror to self-hosted release-please.