### PR TITLE
fix: merge next into release PR to carry code changes to master

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,9 +11,10 @@ name: Release Please
 # `next` receives new commits, which:
 #   1. Reads the Release-As version from the commit footer
 #   2. Opens a release PR targeting `master` with --release-as
-#   3. On merge, push to `master` triggers this workflow again
-#   4. github-release creates vX.Y.Z tag and GitHub Release
-#   5. publish-npm.yml picks up the release event and publishes to npm
+#   3. Merges `next` into the release PR branch so code changes are included
+#   4. On merge, push to `master` triggers this workflow again
+#   5. github-release creates vX.Y.Z tag and GitHub Release
+#   6. publish-npm.yml picks up the release event and publishes to npm
 #
 # Uses the official Google release-please from npm (not the Stainless fork,
 # which has broken TypeScript compilation on newer Node versions).
@@ -103,6 +104,46 @@ jobs:
             echo "prs_created=true" >> "$GITHUB_OUTPUT"
           else
             echo "prs_created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge next code into release PR
+        if: github.ref == 'refs/heads/next'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # release-please creates a PR with only version bumps (CHANGELOG,
+          # package.json, version.ts, etc). The actual SDK code changes are
+          # on `next` but NOT included in the release PR. This step merges
+          # `next` into the release PR branch so the PR carries both code
+          # and version bumps to master.
+          #
+          # Without this, master gets version bumps only — the published
+          # npm package has the new version number but old code.
+
+          PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName')
+          if [ -z "$PR_BRANCH" ]; then
+            echo "No open release PR found, skipping merge"
+            exit 0
+          fi
+
+          echo "Found release PR branch: $PR_BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$PR_BRANCH" next
+          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+
+          # -X ours: on conflicts, prefer the release-please branch's version
+          # bumps (canonical version + changelog). Non-conflicting code changes
+          # from next are included normally.
+          if git merge origin/next --no-edit -X ours; then
+            git push origin "$PR_BRANCH"
+            echo "Successfully merged next into release PR branch"
+          else
+            echo "::error::Failed to merge next into release PR"
+            git merge --abort
+            exit 1
           fi
 
       - name: Run release-please (github-release)


### PR DESCRIPTION
## Problem

release-please creates its release PR with only version bumps (`CHANGELOG.md`, `package.json`, `version.ts`, etc.). The actual SDK code changes — the generated API client, models, examples — live on `next` but are **not** included in the release PR.

When the release PR is merged to `master`, the result is a new version number sitting on top of the old code. The published npm package then advertises the new version but contains stale SDK code. This is exactly the broken state we're in now: `v6.83.0` exists on `master`, but ~227 files of SDK code that were promoted to `next` never made it to `master`.

## Fix

Adds a new `Merge next code into release PR` step to `release-please.yml` that runs after release-please creates/updates the release PR:

1. Locates the open release-please PR (label: `autorelease: pending`)
2. Checks out the PR's head branch
3. Merges `origin/next` into it with `-X ours` — the release-please version bumps and changelog win on conflicts, while all non-conflicting code changes from `next` are brought in normally
4. Pushes the updated PR branch

This ensures the release PR carries both version bumps **and** the real SDK code changes to `master`, so the tag, GitHub release, and npm publish all reflect the actual promoted code.

## Details

- The step is gated on `github.ref == 'refs/heads/next'` so it only runs during phase 1 (release PR creation), not during the master release-tagging phase.
- Uses `SDK_WRITE_TOKEN` for the `gh` CLI lookup and the git push.
- If no open release PR exists (e.g. release-please didn't create one), the step exits 0 and does nothing.
- `-X ours` is the merge strategy on the release-please branch: canonical version + changelog win; everything else from `next` is applied normally.

## Follow-up

This fixes the workflow going forward. To repair the *current* broken state where the `v6.83.0` SDK code is on `next` but missing from `master`, see the companion sync PR: **#LINK** (next → master).
