### PR TITLE
fix: resolve race condition in release-please code-carry merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -111,6 +111,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
           REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
           # release-please creates a PR with only version bumps (CHANGELOG,
           # package.json, version.ts, etc). The actual SDK code changes are
@@ -121,9 +122,27 @@ jobs:
           # Without this, master gets version bumps only — the published
           # npm package has the new version number but old code.
 
-          PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName')
+          # Use the PR number from the release-please step directly (avoids
+          # GitHub API eventual-consistency race where gh pr list doesn't see
+          # a PR that was created milliseconds ago).
+          PR_BRANCH=""
+          if [ -n "$PR_NUM" ]; then
+            sleep 3  # brief propagation delay
+            PR_BRANCH=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+          fi
+
+          # Fallback: query by label with retry
           if [ -z "$PR_BRANCH" ]; then
-            echo "No open release PR found, skipping merge"
+            for i in 1 2 3; do
+              PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName' 2>/dev/null || true)
+              if [ -n "$PR_BRANCH" ]; then break; fi
+              echo "PR not found yet, retrying in 5s (attempt $i)..."
+              sleep 5
+            done
+          fi
+
+          if [ -z "$PR_BRANCH" ]; then
+            echo "::warning::No open release PR found after retries, skipping merge"
             exit 0
           fi
 


### PR DESCRIPTION
## Problem

The **"Merge next code into release PR"** step was silently failing due to a GitHub API race condition.

When release-please creates a PR, the next step immediately queries `gh pr list` to find it. But GitHub's API has eventual consistency — the PR wasn't indexed yet, so the query returned empty.

Result: the merge step printed `"No open release PR found, skipping merge"` and exited. The release PR had **only 6 version-bump files** (CHANGELOG, package.json, version.ts, etc.) — **no SDK code changes**.

This is exactly what happened with PR #439.

## Fix

1. **Use the `pr_number` output** from the release-please step directly (via `gh pr view`) instead of querying `gh pr list`
2. **Fallback to `gh pr list` with retries** (3 attempts, 5s interval) for robustness
3. **Add a 3s propagation delay** before the first query

## Evidence

Workflow run #27786628012 log:
```
Merge next code into release PR | No open release PR found, skipping merge
```

PR #439 before fix: 6 files (version bumps only)
PR #439 after manual merge: 265 files (full SDK code)