### PR TITLE
fix: remove `|| true` from github-release step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -174,7 +174,7 @@ jobs:
             --target-branch master \
             --config-file release-please-config.json \
             --manifest-file .release-please-manifest.json \
-            2>&1 || true
+            2>&1
 
       - name: Enable auto-merge on release PRs
         if: github.ref == 'refs/heads/next' && steps.release-pr.outputs.prs_created == 'true'


### PR DESCRIPTION
## What

Removes `|| true` from the `Run release-please (github-release)` step in `release-please.yml`.

## Why

The `|| true` silently swallows tag/release creation failures. If tag creation fails (transient API error, rate limit, ruleset), release-please reports success and the publish workflow never triggers — you'd never know.

## Scope

Only the `github-release` step is changed. All other `|| true` occurrences (grep fallbacks, gh CLI fallbacks, conflict resolution) are intentional and left untouched.

## Consistency

Same fix as telnyx-python PR #329.