### PR TITLE
fix: release-please dirty worktree preventing code merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install release-please@17
+        run: npm install --no-save release-please@17
 
       - name: Read Release-As version from next branch
         if: github.ref == 'refs/heads/next'


### PR DESCRIPTION
## Problem

`npm install release-please@17` modifies `package.json` (adds release-please as a dependency), dirtying the working tree. When the **"Merge next code into release PR"** step tries `git checkout -B "$PR_BRANCH"`, git refuses because `package.json` has uncommitted local changes:

```
error: Your local changes to the following files would be overwritten by checkout:
	package.json
Aborting
```

This has been failing on every push to `next` since the self-hosted release-please pipeline was set up. The promote-to-prod workflow pushes code to `next`, but release-please can't merge that code into the release PR — so the release PR only contains version bumps, not actual SDK changes.

## Fix

Change `npm install release-please@17` → `npm install --no-save release-please@17`

`--no-save` installs the package to `node_modules` without modifying `package.json` or `package-lock.json`. The subsequent `npx release-please` calls work exactly the same.