### PR TITLE
fix: restore release trigger in publish-npm.yml

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,8 @@
 name: Publish NPM
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
## Problem

After the STLC cutover, `publish-npm.yml` lost its `release: [published]` trigger. npm publishes stopped — the last published version is **6.83.0** (Jun 18), even though GitHub releases v7.0.0 and v7.1.0 were created.

## Root Cause

The `promote-to-prod.yml` workflow on `telnyx-typescript-staging` does:
1. `git rm -rf .` + `rsync` staging tree → prod `next`
2. Restore prod-owned files via `git checkout next -- publish-npm.yml`

But step 1 already overwrote `next`'s working tree with staging content. `git checkout next -- publish-npm.yml` restores from the `next` branch ref, which after the first promote contains staging's version (workflow_dispatch only, no release trigger). This creates a corrupting cycle — each promote re-strips the trigger.

## Fix

This PR restores the `release: [published]` trigger on master.

A companion PR on `telnyx-typescript-staging` fixes `promote-to-prod.yml` to restore all prod-owned workflow files from `origin/master` (canonical prod source) instead of `next` (staging-corrupted), preventing future corruption.

## Post-Merge

After both PRs merge, manually trigger `publish-npm.yml` for v7.1.0 to get npm unstuck. Future releases will auto-publish.