### PR TITLE
fix: bump package version to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telnyx",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Telnyx API SDK for global Voice, SMS, MMS, WhatsApp, Fax, Wireless IoT, SIP Trunking, and Call Control.",
   "author": "Telnyx <support@telnyx.com>",
   "types": "dist/index.d.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '7.1.0'; // x-release-please-version
+export const VERSION = '7.2.0'; // x-release-please-version


### PR DESCRIPTION
Bump `package.json` and `src/version.ts` from 7.1.0 → 7.2.0 to match the v7.2.0 GitHub release. Needed because the release was created manually instead of through release-please.