### PR TITLE
fix: exempt mcp-server from no-restricted-imports rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,10 @@ export default tseslint.config(
     },
   },
   {
-    files: ['tests/**', 'examples/**'],
+    // mcp-server is a separate workspace package that depends on `telnyx`
+    // via "workspace:*" — it imports the SDK as a package consumer, not as
+    // internal code that should use relative imports.
+    files: ['tests/**', 'examples/**', 'packages/mcp-server/**'],
     rules: {
       'no-restricted-imports': 'off',
     },


### PR DESCRIPTION
## Problem

CI lint is failing on `next` with 8 `no-restricted-imports` errors — all from `packages/mcp-server/src/`:

```
packages/mcp-server/src/auth.ts             4:1  error  'telnyx' import is restricted
packages/mcp-server/src/code-tool-types.ts   3:1  error  'telnyx' import is restricted
packages/mcp-server/src/code-tool-worker.ts  8:1  error  'telnyx' import is restricted
packages/mcp-server/src/code-tool.ts        18:1  error  'telnyx' import is restricted
packages/mcp-server/src/http.ts             5:1  error  'telnyx' import is restricted
packages/mcp-server/src/server.ts          10:1  error  'telnyx' import is restricted
packages/mcp-server/src/server.ts          11:1  error  'telnyx' import is restricted
packages/mcp-server/src/types.ts             3:1  error  'telnyx' import is restricted
```

## Root Cause

The `no-restricted-imports` rule blocks importing the `telnyx` package by name (regex `^telnyx(/.*)?`) to force internal code to use relative imports. This is correct for the main SDK source — internal modules should not import the published package name.

However, `mcp-server` is a **separate workspace package** (`packages/mcp-server/`) that declares `"telnyx": "workspace:*"` in its `package.json`. It's a legitimate consumer of the SDK, not internal code. Its imports of `Telnyx` and `ClientOptions` from `'telnyx'` are correct — it should NOT use relative imports.

## Fix

Add `packages/mcp-server/**` to the eslint exemption list alongside `tests/` and `examples/`:

```diff
-    files: ['tests/**', 'examples/**'],
+    files: ['tests/**', 'examples/**', 'packages/mcp-server/**'],
```

## Verification

After this change, eslint will skip the `no-restricted-imports` check for all files under `packages/mcp-server/`, resolving all 8 errors.