### PR TITLE
fix: remove --target-branch from release-pr so it scans next for commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,6 @@ jobs:
             release-pr
             --repo-url "${{ github.repositoryUrl }}"
             --token "${{ secrets.SDK_WRITE_TOKEN }}"
-            --target-branch master
             --config-file release-please-config.json
             --manifest-file .release-please-manifest.json
             --local


### PR DESCRIPTION
## Problem

release-please with `--target-branch master` scans **master** for commits since the last release.
But promote commits land on **next**, not master. So release-please finds 0 commits and skips.

## Fix

Remove `--target-branch master` from the `release-pr` step. Without it, release-please:
1. Scans the current HEAD (`next`) for commits — finds our `feat: promote` commits ✅
2. Creates the release PR targeting the default branch (`master`) — same target ✅

## Verification

After merge, the next push to `next` (from promote-to-prod) will trigger release-please
which will scan `next`, find the `feat:` commits, and create a release PR on master.