### PR TITLE
ci: check SDK write token in release doctor

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. Add it as a repository secret so release-please can open release PRs and create releases.")
 fi
 
 lenErrors=${#errors[@]}
@@ -19,4 +19,3 @@ if [[ lenErrors -gt 0 ]]; then
 fi
 
 echo "The environment is ready to push releases!"
-


### PR DESCRIPTION
Updates Release Doctor to validate the current release token used by telnyx-node.\n\nReference: team-telnyx/telnyx-ruby keeps Release Doctor wired to SDK_WRITE_TOKEN and does not require RELEASE_PLEASE_TOKEN.\n\nWhy:\n- release-please.yml uses SDK_WRITE_TOKEN for release PRs and GitHub releases.\n- release-doctor.yml already passes SDK_WRITE_TOKEN into bin/check-release-environment.\n- The helper still checked the obsolete RELEASE_PLEASE_TOKEN, which made release-please branches fail even though the current release path does not use that token.\n\nValidation:\n- bash -n bin/check-release-environment\n- SDK_WRITE_TOKEN=dummy bash ./bin/check-release-environment\n- env -u SDK_WRITE_TOKEN bash ./bin/check-release-environment exits 1 with the new SDK_WRITE_TOKEN message\n- Ruby YAML parse for .github/workflows/release-doctor.yml\n- git diff --check