### PR TITLE
fix(release): scan next's commits in release-pr (stop depending on master hotfixes)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,6 +93,16 @@ jobs:
             ARGS+=(--release-as "${{ steps.version.outputs.version }}")
           fi
 
+          # Widen the --local commit scan to next's promote commits: release-pr
+          # collects commits since the last release on the TARGET branch (master),
+          # so with only hidden ci:-typed commits on master it silently skips
+          # (releases previously depended on coincidental fix-typed hotfixes).
+          # next always contains master (the promote enforces ancestry), so
+          # pointing the local refs at HEAD only widens the scan; the PR is
+          # still created against master via the API.
+          git branch -f master HEAD 2>/dev/null || true
+          git update-ref refs/remotes/origin/master HEAD
+
           OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
           echo "$OUTPUT"
 


### PR DESCRIPTION
release-pr's --local scan reads commits since the last release on the target branch only; next's chore promotes + Release-As footers are invisible to it, so releases only built when master coincidentally had fix-typed hotfixes (see the java 6.80.0 stall, unblocked manually via #195). Point the local default-branch refs at HEAD (= next tip, which always contains the default branch now that promotes enforce ancestry) before invoking release-please: the scan sees the promote commits (chore = visible in changelog-sections), while PR creation still targets the default branch via the API.