### PR TITLE
fix: restore SDK_WRITE_TOKEN check in release doctor

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. Add it as a repository secret.")
 fi
 
 lenErrors=${#errors[@]}
@@ -19,4 +19,3 @@ if [[ lenErrors -gt 0 ]]; then
 fi
 
 echo "The environment is ready to push releases!"
-


### PR DESCRIPTION
The staging variant of bin/check-release-environment (checks RELEASE_PLEASE_TOKEN) merged into master via release 7.6.0 during the automerge era. The 07-04 remediation fixed prod next, but every subsequent promote restores this prod-owned file FROM MASTER — faithfully re-propagating the contaminated copy, which is why the release doctor fails on the current release PR (run 28830116414: script demands RELEASE_PLEASE_TOKEN, workflow provides SDK_WRITE_TOKEN). Master is the canonical source; fixing it here makes every future promote restore the right copy. next will be re-synced after merge.