### PR TITLE
fix(release): make release-pr's --local scan see next's commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,6 +102,13 @@ jobs:
           # still created against master via the API.
           git branch -f master HEAD 2>/dev/null || true
           git update-ref refs/remotes/origin/master HEAD
+          # --local mode clones from --repo-url — a FRESH GitHub clone whose
+          # refs ignore the repoint above (it only rewrites this workspace), so
+          # the scan saw 0 commits on a quiet master and silently skipped the
+          # release PR (2026-07-09). Rewrite the URL to this workspace so the
+          # CLI clones the repointed refs; API PR-creation still parses
+          # owner/repo from the URL string.
+          git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "${{ github.repositoryUrl }}"
 
           OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
           echo "$OUTPUT"


### PR DESCRIPTION
## Problem

Staging promotes landed on `next` (2026-07-09 evening) but **no release PR opened**. The run log shows why: `release-pr --local` git-clones the repo from `--repo-url` (GitHub) into /tmp, so the workflow's ref-repoint (local default branch -> next HEAD) never reaches the scan. On a quiet default branch it collects **0 commits** and silently skips. Previous cycles only worked because `fix:`-typed pipeline-hardening commits happened to be landing on the default branch directly.

## Fix

One line after the repoint: `git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "<repositoryUrl>"` — the CLI's clone now comes from the workspace (repointed refs included); PR creation still goes through the API using owner/repo parsed from the URL string.

Fleet-wide: 6 prod repos + the reusable `sdk-release-please.yml` (php's path).

## Verify

After merge, re-run the release-please workflow on the latest `next` push — a release PR should open with the promote commits in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
