### PR TITLE
fix(release): publish MCP npm package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,3 +32,15 @@ jobs:
       - name: Publish to NPM
         run: |
           bash ./bin/publish-npm
+
+          # The generated MCP package has an independent manifest version.
+          # Publish it under the release tag's SDK version so both artifacts
+          # are immutable products of the same release commit.
+          ROOT_VERSION="$(jq -r -e '.version' package.json)"
+          jq --arg version "$ROOT_VERSION" '.version = $version' \
+            packages/mcp-server/package.json > packages/mcp-server/package.json.tmp
+          mv packages/mcp-server/package.json.tmp packages/mcp-server/package.json
+          (
+            cd packages/mcp-server
+            bash ../../bin/publish-npm
+          )

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -16,6 +16,16 @@ cd dist
 PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
 VERSION="$(jq -r -e '.version' ./package.json)"
 
+# Release publication can be retried after a partial failure (for example,
+# when the SDK package was published but a workspace package was not). Treat
+# an already-published exact version as success so the remaining packages can
+# continue.
+PUBLISHED_VERSION="$(npm view "$PACKAGE_NAME@$VERSION" version --json 2>/dev/null || true)"
+if [[ "$(echo "$PUBLISHED_VERSION" | jq -r 'select(type == "string") // empty')" == "$VERSION" ]]; then
+  echo "$PACKAGE_NAME@$VERSION is already published; skipping"
+  exit 0
+fi
+
 # Get latest version from npm
 #
 # If the package doesn't exist, npm will return:


### PR DESCRIPTION
## Summary
- publish the generated `telnyx-mcp` workspace package alongside the root SDK package
- align the MCP package version with the immutable SDK release version
- make npm publication idempotent so a partial release can be safely retried without republishing an existing artifact

## Root cause
The release workflow only invoked `bin/publish-npm` from the repository root. That publishes `telnyx`, while the rate-limited MCP server lives in `packages/mcp-server` as `telnyx-mcp`. As a result, `telnyx@7.11.0` was published successfully, but the fixed MCP artifact was not present in that tarball and `telnyx-mcp` remained at 6.83.0.

## Verification
- `bash -n bin/publish-npm`
- `actionlint .github/workflows/publish-npm.yml`
- `git diff --check`
- retry path against already-published `telnyx@7.11.0` exits successfully without publishing
- MCP build succeeds with release-aligned version 7.11.0
- MCP npm dry-run tarball: `telnyx-mcp@7.11.0`, 135 files, includes `express-rate-limit@^8.2.1`
- full generated MCP tests, lint, and build pass on production commit 17cbfbf1

## Follow-up
After merge, manually dispatch `Publish NPM`. The existing root package will be skipped and `telnyx-mcp@7.11.0` will publish through the repository's npm OIDC trusted publisher.