### PR TITLE
fix(ci): ignore closed release PR events

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -381,6 +381,10 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn(
             "startsWith(github.event.pull_request.title, 'release: ')", workflow
         )
+        self.assertIn("github.event.pull_request.state == 'open'", workflow)
+        self.assertIn(
+            "github.event.label.name == 'autorelease: pending'", workflow
+        )
 
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -46,8 +46,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
+        github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release-please--') &&
-        startsWith(github.event.pull_request.title, 'release: ')
+        startsWith(github.event.pull_request.title, 'release: ') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'autorelease: pending')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 65


### PR DESCRIPTION
## Summary
- run the privileged gate only while the Release Please PR is open
- accept `labeled` triggers only for `autorelease: pending`
- prevent post-release `autorelease: tagged` labels from creating noisy failed gate runs

## Validation
- 24/24 behavior tests
- `actionlint .github/workflows/release-pr-auto-merge.yml`
- `git diff --check`