### PR TITLE
ci: harden privileged workflow dependencies

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import copy
+from pathlib import Path
+import re
 import unittest
 import dataclasses
 from unittest import mock
@@ -451,6 +453,30 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn("sha=%s" % HEAD, command)
         self.assertIn("commit_title=release: 4.174.0", command)
         self.assertNotIn("pr", command)
+
+
+class WorkflowDependencyPolicyTests(unittest.TestCase):
+    def test_external_workflow_actions_use_immutable_commit_shas(self):
+        root = Path(__file__).resolve().parents[2]
+        for workflow in sorted((root / ".github/workflows").glob("*.y*ml")):
+            for line_number, line in enumerate(workflow.read_text().splitlines(), 1):
+                match = re.search(r"-\s+uses:\s*([^\s#]+)", line)
+                if not match:
+                    continue
+                action = match.group(1)
+                if action.startswith(("./", "docker://")):
+                    continue
+                with self.subTest(workflow=workflow.name, line=line_number, action=action):
+                    self.assertRegex(action, r"@[0-9a-f]{40}$")
+
+    def test_mcp_publisher_download_is_fixed_and_hash_verified(self):
+        root = Path(__file__).resolve().parents[2]
+        workflow = (root / ".github/workflows/publish-mcp.yml").read_text()
+        self.assertIn("mcp-publisher_1.2.3_linux_amd64.tar.gz", workflow)
+        self.assertIn("868a54268f21580ec97ec9dfc4fc3442a7f69c241ee7c745c7032f2e43cdf47b", workflow)
+        self.assertIn("sha256sum --check", workflow)
+        self.assertNotIn("curl -L", workflow)
+        self.assertNotIn("| tar", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
 
       - name: Install dependencies
         run: pnpm install
@@ -36,7 +36,15 @@ jobs:
 
       - name: Install MCP Publisher CLI
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.2.3/mcp-publisher_1.2.3_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz
+          set -euo pipefail
+          readonly archive="mcp-publisher_1.2.3_linux_amd64.tar.gz"
+          curl --fail --show-error --silent --location \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v1.2.3/${archive}" \
+            --output "${archive}"
+          printf '%s  %s\n' \
+            '868a54268f21580ec97ec9dfc4fc3442a7f69c241ee7c745c7032f2e43cdf47b' \
+            "${archive}" | sha256sum --check
+          tar xzf "${archive}"
           mv mcp-publisher /usr/local/bin/
 
       - name: Login to MCP Registry (GitHub OIDC)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,13 +38,13 @@ jobs:
     if: github.repository == 'team-telnyx/telnyx-node'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           token: ${{ secrets.SDK_WRITE_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/release-pr-guard.yml
+++ b/.github/workflows/release-pr-guard.yml
@@ -18,7 +18,7 @@ jobs:
     name: protected-paths
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Block prod-owned changes in generated release PRs


### PR DESCRIPTION
Pin every mutable third-party action reference in active release workflows. Replace the MCP publisher pipe-to-shell install with a fixed Linux amd64 artifact, a verified upstream SHA-256, and extraction only after verification. Add fail-closed policy regressions.

The separate missing Jest CI gate remains blocked by three reproducible pre-existing Ed25519 webhook integration test failures and is not hidden in this security PR.

Validation:
- all `.github/scripts/test_*.py`
- `actionlint` (excluding the pre-existing SC2034 warning in release-please)
- verified the upstream v1.2.3 archive SHA-256
- `git diff --check`