### PR TITLE
fix: refresh release PR lockfile

### DIFF
--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -15,6 +15,7 @@ class NodeGateTests(unittest.TestCase):
   w=(ROOT/'.github/workflows/release-please.yml').read_text()
   self.assertIn('pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',w)
   self.assertIn('pnpm install --lockfile-only --ignore-scripts',w)
+  self.assertIn('pnpm exec prettier --write pnpm-lock.yaml',w)
   self.assertIn('git add pnpm-lock.yaml',w)
  def test_readiness_dry_run(self):
   w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text(); self.assertIn('--dry-run',w); self.assertNotIn('--merge',w)

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -11,6 +11,11 @@ class NodeGateTests(unittest.TestCase):
   w=(ROOT/'.github/workflows/next-readiness.yml').read_text(); self.assertIn('validate_next_provenance.py',w); self.assertNotIn('./scripts/lint',w); self.assertNotIn('./scripts/build',w)
  def test_npm_availability(self):
   w=(ROOT/'.github/workflows/release-please.yml').read_text(); self.assertIn('Verify NPM release availability',w); self.assertIn('verify_npm_release.py',w); self.assertNotIn('release-pr-auto-merge.yml',w); self.assertNotIn('Dispatch exact-head release PR gate',w)
+ def test_release_sync_refreshes_lockfile_after_version_restore(self):
+  w=(ROOT/'.github/workflows/release-please.yml').read_text()
+  self.assertIn('pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',w)
+  self.assertIn('pnpm install --lockfile-only --ignore-scripts',w)
+  self.assertIn('git add pnpm-lock.yaml',w)
  def test_readiness_dry_run(self):
   w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text(); self.assertIn('--dry-run',w); self.assertNotIn('--merge',w)
 if __name__=='__main__': unittest.main()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -247,6 +247,7 @@ jobs:
           # was generated. Refresh only the lockfile so frozen CI consumes the
           # exact release version instead of failing before lint/build.
           pnpm install --lockfile-only --ignore-scripts
+          pnpm exec prettier --write pnpm-lock.yaml
           git add pnpm-lock.yaml
 
           # Commit if there are changes

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: '10.30.1'
+
       - name: Install release-please
         run: npm install --no-save release-please@17
 
@@ -237,6 +242,12 @@ jobs:
             fi
           done
           rm -rf "$STASH_DIR"
+
+          # release-please changes package.json's version after next's lockfile
+          # was generated. Refresh only the lockfile so frozen CI consumes the
+          # exact release version instead of failing before lint/build.
+          pnpm install --lockfile-only --ignore-scripts
+          git add pnpm-lock.yaml
 
           # Commit if there are changes
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- set up the pinned pnpm version in Release Please
- regenerate pnpm-lock.yaml after restoring release-please version files
- add a regression contract for frozen-lockfile compatibility

## Validation
- RED: release workflow omitted lockfile refresh
- GREEN: python3 .github/scripts/test_release_pr_ci_gate.py -v
- git diff --check

Note: actionlint still reports the pre-existing SC2034 warning for the unrelated attempt variable.