### PR TITLE
fix: install tools before formatting release lockfile

### DIFF
--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -15,7 +15,10 @@ class NodeGateTests(unittest.TestCase):
   w=(ROOT/'.github/workflows/release-please.yml').read_text()
   self.assertIn('pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',w)
   self.assertIn('pnpm install --lockfile-only --ignore-scripts',w)
+  self.assertIn('pnpm install --frozen-lockfile --ignore-scripts',w)
   self.assertIn('pnpm exec prettier --write pnpm-lock.yaml',w)
+  self.assertLess(w.index('pnpm install --lockfile-only --ignore-scripts'),w.index('pnpm install --frozen-lockfile --ignore-scripts'))
+  self.assertLess(w.index('pnpm install --frozen-lockfile --ignore-scripts'),w.index('pnpm exec prettier --write pnpm-lock.yaml'))
   self.assertIn('git add pnpm-lock.yaml',w)
  def test_readiness_dry_run(self):
   w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text(); self.assertIn('--dry-run',w); self.assertNotIn('--merge',w)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -247,6 +247,7 @@ jobs:
           # was generated. Refresh only the lockfile so frozen CI consumes the
           # exact release version instead of failing before lint/build.
           pnpm install --lockfile-only --ignore-scripts
+          pnpm install --frozen-lockfile --ignore-scripts
           pnpm exec prettier --write pnpm-lock.yaml
           git add pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- install the refreshed frozen dependency graph after lockfile-only generation
- make pinned Prettier available after git clean removes node_modules
- assert lockfile refresh, frozen install, and formatting happen in order

## Evidence
- RED: hosted release run 33475840959 failed because prettier was unavailable
- GREEN: python3 .github/scripts/test_release_pr_ci_gate.py -v
- exact release-head simulation passed frozen install, lint, and build after this sequence