### PR TITLE
fix: attest Node release lockfile metadata

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -112,7 +112,7 @@ class GateConfig:
                 "default_branch": "master",
                 "staging_repository": "team-telnyx/telnyx-typescript-staging",
                 "release_files": {
-                    "CHANGELOG.md", "package.json", "src/version.ts",
+                    "CHANGELOG.md", "package.json", "pnpm-lock.yaml", "src/version.ts",
                     ".release-please-manifest.json",
                 },
                 "checks": {

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -183,6 +183,12 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         with self.assertRaisesRegex(GateError, "unsupported repository"):
             GateConfig.for_repository("team-telnyx/telnyx-java")
 
+    def test_node_lockfile_is_version_coupled_release_metadata(self):
+        node = GateConfig.for_repository("team-telnyx/telnyx-node")
+        self.assertIn("pnpm-lock.yaml", node.release_files)
+        python = GateConfig.for_repository("team-telnyx/telnyx-python")
+        self.assertNotIn("pnpm-lock.yaml", python.release_files)
+
     def test_promotion_must_be_reachable_from_current_next(self):
         client = FixtureClient()
         client.snapshot["promotion"]["reachable_from_next"] = False


### PR DESCRIPTION
## Summary
- classify pnpm-lock.yaml as Node-only release metadata
- preserve fail-closed exact-tree checks for all non-release files
- add a repository-scoped regression test

## Evidence
- RED: release provenance run 33476532068 rejected the required lockfile delta
- GREEN: python3 .github/scripts/test_release_pr_auto_merge.py -v (30/30)
- python3 .github/scripts/test_release_pr_ci_gate.py -v