### PR TITLE
ci: harden release PR provenance

### DIFF
--- a/.github/scripts/copy_package_version.py
+++ b/.github/scripts/copy_package_version.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Copy only Release Please's package version onto generated package.json."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+LINE_RE = re.compile(r'(?m)^(?P<prefix>\s*"version"\s*:\s*")[^"]+(?P<suffix>",?\s*)$')
+
+
+def fail(message: str) -> "None":
+    raise SystemExit(message)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        fail("usage: copy_package_version.py RELEASE_PACKAGE TARGET_PACKAGE")
+    release_path, target_path = map(Path, sys.argv[1:])
+    try:
+        release_text = release_path.read_text(encoding="utf-8")
+        target_text = target_path.read_text(encoding="utf-8")
+        release_data = json.loads(release_text)
+        json.loads(target_text)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        fail("could not read valid package manifests: %s" % exc)
+    version = release_data.get("version") if isinstance(release_data, dict) else None
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        fail("release package must contain one semantic version")
+    matches = list(LINE_RE.finditer(target_text))
+    if len(matches) != 1:
+        fail("target package must contain exactly one root version field")
+    match = matches[0]
+    updated = target_text[: match.start()] + match.group("prefix") + version + match.group("suffix") + target_text[match.end() :]
+    try:
+        parsed = json.loads(updated)
+    except json.JSONDecodeError as exc:
+        fail("updated target package is invalid JSON: %s" % exc)
+    if not isinstance(parsed, dict) or parsed.get("version") != version:
+        fail("updated target package version did not match")
+    target_path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/install_release_please.sh
+++ b/.github/scripts/install_release_please.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="17.11.2"
+EXPECTED_INTEGRITY="sha512-we0+NgyHjvczxrilD6aujnRNuASd65Jem0dY5evevxSZvz8BnKnB/QRN3UzGA229fcV09lKCYbqeE9HgkXzGmA=="
+PACK_JSON=$(npm pack "release-please@${VERSION}" --json --ignore-scripts)
+TARBALL=$(node -e 'const p=JSON.parse(process.argv[1]); if(!Array.isArray(p)||p.length!==1||!p[0].filename) process.exit(1); process.stdout.write(p[0].filename)' "$PACK_JSON")
+ACTUAL_INTEGRITY=$(node -e 'const p=JSON.parse(process.argv[1]); if(!Array.isArray(p)||p.length!==1||!p[0].integrity) process.exit(1); process.stdout.write(p[0].integrity)' "$PACK_JSON")
+if [[ "$ACTUAL_INTEGRITY" != "$EXPECTED_INTEGRITY" ]]; then
+  echo "release-please integrity mismatch: expected $EXPECTED_INTEGRITY, got $ACTUAL_INTEGRITY" >&2
+  rm -f -- "$TARBALL"
+  exit 1
+fi
+npm install --no-save --ignore-scripts --package-lock=false "./$TARBALL"
+rm -f -- "$TARBALL"
+./node_modules/.bin/release-please --version

--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -47,6 +47,30 @@ class ChecksPending(GateError):
     """Expected checks have not reached an accepted terminal state."""
 
 
+def require_version_only_change(kind: str, head_text: str, next_text: str, expected_version: str) -> None:
+    """Require the head file to equal next after replacing one marked version."""
+    patterns = {
+        "json-version": re.compile(r'(?m)^(?P<prefix>\s*"version"\s*:\s*")[^"]+(?P<suffix>",?\s*)$'),
+        "toml-version": re.compile(r'(?m)^(?P<prefix>version\s*=\s*")[^"]+(?P<suffix>"\s*)$'),
+        "gradle-version": re.compile(r'(?m)^(?P<prefix>version\s*=\s*")[^"]+(?P<suffix>"\s*// x-release-please-version\s*)$'),
+    }
+    pattern = patterns.get(kind)
+    if pattern is None:
+        raise GateError(f"unsupported version-only file kind: {kind}")
+    head_matches = list(pattern.finditer(head_text))
+    next_matches = list(pattern.finditer(next_text))
+    if len(head_matches) != 1 or len(next_matches) != 1:
+        raise GateError(f"version-only file marker drift for {kind}")
+    head_match, next_match = head_matches[0], next_matches[0]
+    head_version = head_text[head_match.end("prefix"):head_match.start("suffix")]
+    next_version = next_text[next_match.end("prefix"):next_match.start("suffix")]
+    if head_version != expected_version:
+        raise GateError(f"release manifest version {head_version!r} != {expected_version!r}")
+    normalized = head_text[:head_match.end("prefix")] + next_version + head_text[head_match.start("suffix"): ]
+    if normalized != next_text:
+        raise GateError("release manifest changed outside its marked version field")
+
+
 @dataclasses.dataclass(frozen=True)
 class GateConfig:
     repository: str
@@ -54,6 +78,7 @@ class GateConfig:
     staging_repository: str
     release_files: frozenset[str]
     expected_checks: Mapping[str, str]
+    version_only_files: Mapping[str, str]
     author_login: str = "ankitTelnyx"
     author_id: int = 253082483
     staging_default_branch: str = "main"
@@ -150,6 +175,30 @@ class GateConfig:
                     "CodeQL": advanced_security,
                 },
             },
+            "team-telnyx/telnyx-java": {
+                "default_branch": "master",
+                "staging_repository": "team-telnyx/telnyx-java-staging",
+                "release_files": {
+                    "CHANGELOG.md", "README.md", "build.gradle.kts",
+                    ".release-please-manifest.json",
+                },
+                "checks": {
+                    "build": github, "lint": github,
+                    "test": github, "protected-paths": github,
+                    "release doctor": github, "Analyze (actions)": github,
+                    "Analyze (java-kotlin)": github, "CodeQL": advanced_security,
+                },
+            },
+        }
+        version_only_inventory = {
+            "team-telnyx/telnyx-python": {"pyproject.toml": "toml-version"},
+            "team-telnyx/telnyx-node": {"package.json": "json-version"},
+            "team-telnyx/telnyx-java": {"build.gradle.kts": "gradle-version"},
+        }
+        exact_generated_inventory = {
+            "team-telnyx/telnyx-node": {"pnpm-lock.yaml"},
+            "team-telnyx/telnyx-ruby": {"telnyx.gemspec"},
+            "team-telnyx/telnyx-php": {"composer.json", "composer.lock"},
         }
         values = inventory.get(repository)
         if values is None:
@@ -158,7 +207,8 @@ class GateConfig:
             repository=repository,
             default_branch=values["default_branch"],
             staging_repository=values["staging_repository"],
-            release_files=frozenset(values["release_files"]),
+            release_files=frozenset(set(values["release_files"]) - exact_generated_inventory.get(repository, set())),
+            version_only_files=version_only_inventory.get(repository, {}),
             expected_checks=dict(values["checks"]),
         )
 
@@ -292,7 +342,7 @@ class ReleasePRAutoMergeGate:
         parent = self._mapping(parents[0], "head parent")
         self._require(parent.get("sha") == default_sha, "head parent is not current base")
 
-        self._attest_tree(snapshot)
+        self._attest_tree(snapshot, version)
         staging_sha, config_sha = self._attest_provenance(snapshot, version)
         self._attest_checks(snapshot, head_sha)
         return Attestation(
@@ -305,11 +355,17 @@ class ReleasePRAutoMergeGate:
             config_sha,
         )
 
-    def _attest_tree(self, snapshot: Mapping[str, Any]) -> None:
+    def _attest_tree(self, snapshot: Mapping[str, Any], version: str) -> None:
         head_tree = self._tree(snapshot.get("head_tree"), "PR head tree")
         next_tree = self._tree(snapshot.get("next_tree"), "next tree")
         head_filtered = {k: v for k, v in head_tree.items() if k not in self.config.release_files}
         next_filtered = {k: v for k, v in next_tree.items() if k not in self.config.release_files}
+        contents = snapshot.get("version_file_contents")
+        self._require(isinstance(contents, Mapping), "missing version-only file contents")
+        for path, kind in self.config.version_only_files.items():
+            pair = contents.get(path) if isinstance(contents, Mapping) else None
+            self._require(isinstance(pair, Mapping), "missing exact contents for version-only file %s" % path)
+            require_version_only_change(kind, str(pair.get("head", "")), str(pair.get("next", "")), version)
         self._require(head_filtered == next_filtered, "non-release tree differs from current next")
 
     def _attest_provenance(
@@ -579,6 +635,10 @@ class GitHubClient:
             "head_commit": head_commit,
             "head_tree": self._ls_tree(head_sha),
             "next_tree": self._ls_tree(next_sha),
+            "version_file_contents": {
+                path: {"head": self._show_file(head_sha, path), "next": self._show_file(next_sha, path)}
+                for path in self.config.version_only_files
+            },
             "promotion": promotion,
             "staging_prs": staging_prs,
             "generated_staging_prs": generated_staging_prs,
@@ -697,6 +757,12 @@ class GitHubClient:
                     raise GateError("ambiguous generated staging ancestor PR")
                 return generated
         raise GateError("no generated staging ancestor in bounded history")
+
+    def _show_file(self, sha: str, path: str) -> str:
+        completed = subprocess.run(["git", "show", "%s:%s" % (sha, path)], text=True, capture_output=True)
+        if completed.returncode != 0:
+            raise GateError("could not read exact file %s at %s" % (path, sha))
+        return completed.stdout
 
     def _ls_tree(self, sha: str) -> Dict[str, Tuple[str, str, str]]:
         completed = subprocess.run(

--- a/.github/scripts/test_copy_package_version.py
+++ b/.github/scripts/test_copy_package_version.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("copy_package_version.py")
+
+class CopyPackageVersionTests(unittest.TestCase):
+    def test_only_version_is_copied_from_release_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); release=root/"release.json"; target=root/"target.json"
+            release.write_text(json.dumps({"version":"7.20.0","description":"stale","dependencies":{"standardwebhooks":"^1.0.0"}},indent=2)+"\n")
+            target.write_text(json.dumps({"version":"7.19.0","description":"generated","dependencies":{}},indent=2)+"\n")
+            subprocess.run(["python3",str(SCRIPT),str(release),str(target)],check=True)
+            self.assertEqual(json.loads(target.read_text()), {"version":"7.20.0","description":"generated","dependencies":{}})
+
+    def test_missing_or_malformed_versions_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); release=root/"release.json"; target=root/"target.json"
+            target.write_text('{"version":"7.19.0"}\n')
+            for payload in ({}, {"version":"v7.20"}, {"version":7}):
+                release.write_text(json.dumps(payload)+"\n")
+                with self.subTest(payload=payload):
+                    self.assertNotEqual(subprocess.run(["python3",str(SCRIPT),str(release),str(target)]).returncode,0)
+
+if __name__ == "__main__": unittest.main()

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -89,6 +89,12 @@ class FixtureClient:
                 "src/telnyx/client.py": ("100644", "blob", "a" * 40),
                 "CHANGELOG.md": ("100644", "blob", "c" * 40),
             },
+            "version_file_contents": {
+                "pyproject.toml": {
+                    "head": 'version = "4.174.0"\n',
+                    "next": 'version = "4.173.0"\n',
+                }
+            },
             "promotion": {
                 "sha": NEXT,
                 "subject": "feat: promote from staging %s" % STAGING,
@@ -175,21 +181,21 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
             "team-telnyx/telnyx-node": ("master", "team-telnyx/telnyx-typescript-staging"),
             "team-telnyx/telnyx-php": ("master", "team-telnyx/telnyx-php-staging"),
             "team-telnyx/telnyx-cli": ("main", "team-telnyx/telnyx-cli-staging"),
+            "team-telnyx/telnyx-java": ("master", "team-telnyx/telnyx-java-staging"),
         }
         for repository, values in expected.items():
             with self.subTest(repository=repository):
                 config = GateConfig.for_repository(repository)
                 self.assertEqual((config.default_branch, config.staging_repository), values)
-        with self.assertRaisesRegex(GateError, "unsupported repository"):
-            GateConfig.for_repository("team-telnyx/telnyx-java")
 
     def test_node_release_requires_complete_jest_check(self):
         node = GateConfig.for_repository("team-telnyx/telnyx-node")
         self.assertEqual(node.expected_checks["test"], "github-actions")
 
-    def test_node_lockfile_is_version_coupled_release_metadata(self):
+    def test_node_lockfile_remains_exact_generated_state(self):
         node = GateConfig.for_repository("team-telnyx/telnyx-node")
-        self.assertIn("pnpm-lock.yaml", node.release_files)
+        self.assertNotIn("pnpm-lock.yaml", node.release_files)
+        self.assertEqual(node.version_only_files, {"package.json": "json-version"})
         python = GateConfig.for_repository("team-telnyx/telnyx-python")
         self.assertNotIn("pnpm-lock.yaml", python.release_files)
 

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -11,15 +11,15 @@ class NodeGateTests(unittest.TestCase):
   w=(ROOT/'.github/workflows/next-readiness.yml').read_text(); self.assertIn('validate_next_provenance.py',w); self.assertNotIn('./scripts/lint',w); self.assertNotIn('./scripts/build',w)
  def test_npm_availability(self):
   w=(ROOT/'.github/workflows/release-please.yml').read_text(); self.assertIn('Verify NPM release availability',w); self.assertIn('verify_npm_release.py',w); self.assertNotIn('release-pr-auto-merge.yml',w); self.assertNotIn('Dispatch exact-head release PR gate',w)
- def test_release_sync_refreshes_lockfile_after_version_restore(self):
+ def test_release_sync_preserves_generated_lockfile(self):
   w=(ROOT/'.github/workflows/release-please.yml').read_text()
   self.assertIn('pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1',w)
-  self.assertIn('pnpm install --lockfile-only --ignore-scripts',w)
+  self.assertIn('copy_package_version.py',w)
+  self.assertIn('git diff --exit-code origin/next -- pnpm-lock.yaml',w)
   self.assertIn('pnpm install --frozen-lockfile --ignore-scripts',w)
-  self.assertIn('pnpm exec prettier --write pnpm-lock.yaml',w)
-  self.assertLess(w.index('pnpm install --lockfile-only --ignore-scripts'),w.index('pnpm install --frozen-lockfile --ignore-scripts'))
-  self.assertLess(w.index('pnpm install --frozen-lockfile --ignore-scripts'),w.index('pnpm exec prettier --write pnpm-lock.yaml'))
-  self.assertIn('git add pnpm-lock.yaml',w)
+  self.assertNotIn('pnpm install --lockfile-only --ignore-scripts',w)
+  self.assertNotIn('pnpm exec prettier --write pnpm-lock.yaml',w)
+  self.assertNotIn('git add pnpm-lock.yaml',w)
  def test_readiness_dry_run(self):
   w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text(); self.assertIn('--dry-run',w); self.assertNotIn('--merge',w)
 if __name__=='__main__': unittest.main()

--- a/.github/scripts/test_release_workflow_hardening.py
+++ b/.github/scripts/test_release_workflow_hardening.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Fleet release-workflow hardening regression tests."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from release_pr_auto_merge import GateError, GateConfig, require_version_only_change
+
+
+class ReleaseWorkflowHardeningTests(unittest.TestCase):
+    def test_mixed_manifests_allow_only_the_expected_version_field(self):
+        cases: list[tuple[str, str, str, str]] = [
+            ("toml-version", "version = \"4.179.0\"\ndependencies = [\"safe\"]\n", "version = \"4.178.0\"\ndependencies = [\"safe\"]\n", "4.179.0"),
+            ("json-version", '{\n  "version": "7.20.0",\n  "dependencies": {}\n}\n', '{\n  "version": "7.19.0",\n  "dependencies": {}\n}\n', "7.20.0"),
+            ("gradle-version", 'version = "6.92.0" // x-release-please-version\ndependencies {}\n', 'version = "6.91.0" // x-release-please-version\ndependencies {}\n', "6.92.0"),
+        ]
+        for kind, head, next_text, version in cases:
+            with self.subTest(kind=kind):
+                require_version_only_change(kind, head, next_text, version)
+                with self.assertRaisesRegex(GateError, "changed outside its marked version field"):
+                    require_version_only_change(kind, self._drift(kind, head), next_text, version)
+
+    @staticmethod
+    def _drift(kind: str, text: str) -> str:
+        if kind == "toml-version":
+            return text.replace("safe", "stale")
+        if kind == "json-version":
+            return text.replace('"dependencies": {}', '"dependencies": {"standardwebhooks": "^1.0.0"}')
+        return text.replace("dependencies {}", 'dependencies { implementation("stale:dependency:1") }')
+
+    def test_fleet_manifest_policy_is_fail_closed(self):
+        expected: dict[str, tuple[dict[str, str], set[str]]] = {
+            "team-telnyx/telnyx-python": ({"pyproject.toml": "toml-version"}, set()),
+            "team-telnyx/telnyx-node": ({"package.json": "json-version"}, {"pnpm-lock.yaml"}),
+            "team-telnyx/telnyx-java": ({"build.gradle.kts": "gradle-version"}, set()),
+            "team-telnyx/telnyx-ruby": ({}, {"telnyx.gemspec"}),
+            "team-telnyx/telnyx-php": ({}, {"composer.json", "composer.lock"}),
+            "team-telnyx/telnyx-go": ({}, set()),
+            "team-telnyx/telnyx-cli": ({}, set()),
+        }
+        for repository, (semantic, exact) in expected.items():
+            with self.subTest(repository=repository):
+                config = GateConfig.for_repository(repository)
+                self.assertEqual(dict(config.version_only_files), semantic)
+                for path in exact:
+                    self.assertNotIn(path, config.release_files)
+
+    def test_release_workflow_uses_verified_exact_tool_and_singleton_pr(self):
+        workflow = Path(".github/workflows/release-please.yml").read_text()
+        self.assertIn(".github/scripts/install_release_please.sh", workflow)
+        self.assertNotIn("release-please@17\n", workflow)
+        self.assertIn("expected exactly one open Release Please PR", workflow)
+        self.assertIn('[ "$open_prs" -ne 1 ]', workflow)
+        self.assertIn("Refusing to synchronize with $release_pr_count open Release Please PRs", workflow)
+        self.assertNotIn('[ "$open_prs" -gt 0 ]', workflow)
+        installer = Path(".github/scripts/install_release_please.sh").read_text()
+        self.assertIn("17.11.2", installer)
+        self.assertIn("we0+NgyHjvczxrilD6aujnRNuASd65Jem0dY5evevxSZvz8BnKnB/QRN3UzGA229fcV09lKCYbqeE9HgkXzGmA==", installer)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("gh auth setup-git", workflow)
+        self.assertIn("--force-with-lease", workflow)
+        self.assertNotIn("git push --force origin", workflow)
+
+    def test_auto_merge_workflow_can_only_attest(self):
+        workflow = Path(".github/workflows/release-pr-auto-merge.yml").read_text()
+        self.assertIn("--dry-run", workflow)
+        self.assertNotIn('DRY_RUN="false"', workflow)
+        self.assertNotIn("INPUT_DRY_RUN", workflow)
+        self.assertNotIn("Attest exact head and merge normally", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate_next_provenance.py
+++ b/.github/scripts/validate_next_provenance.py
@@ -38,7 +38,11 @@ PRODUCTION_POLICY_PATHS = frozenset(
         ".github/scripts/test_classify_production_ci.py", ".github/scripts/validate_next_provenance.py",
         ".github/scripts/test_validate_next_provenance.py", ".github/scripts/verify_npm_release.py",
         ".github/scripts/test_verify_npm_release.py", ".github/scripts/release_pr_auto_merge.py",
-        ".github/scripts/test_release_pr_auto_merge.py", ".github/scripts/test_release_pr_ci_gate.py",
+        ".github/scripts/test_release_pr_auto_merge.py",
+        ".github/scripts/install_release_please.sh",
+        ".github/scripts/test_release_workflow_hardening.py",
+        ".github/scripts/copy_package_version.py",
+        ".github/scripts/test_copy_package_version.py", ".github/scripts/test_release_pr_ci_gate.py",
         "bin/check-release-environment", "bin/publish-npm", "scripts/test-package-imports",
         "release-please-config.json", "pnpm-workspace.yaml",
     }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.SDK_WRITE_TOKEN }}
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -54,7 +55,7 @@ jobs:
           version: '10.30.1'
 
       - name: Install release-please
-        run: npm install --no-save release-please@17
+        run: bash .github/scripts/install_release_please.sh
 
       - name: Read Release-As version from next branch
         if: github.ref == 'refs/heads/next'
@@ -136,7 +137,7 @@ jobs:
           git config --global protocol.file.allow always
           git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "https://github.com/${{ github.repository }}.git"
 
-          OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
+          OUTPUT=$(./node_modules/.bin/release-please "${ARGS[@]}" 2>&1) || true
           echo "$OUTPUT"
 
           # Parse PR number from output if a PR was created
@@ -198,7 +199,7 @@ jobs:
 
           if [ -z "$PR_BRANCH" ]; then
             for i in 1 2 3; do
-              PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName' 2>/dev/null || true)
+              PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq 'if length == 0 then empty elif length == 1 then .[0].headRefName else error("expected exactly one open Release Please PR") end')
               if [ -n "$PR_BRANCH" ]; then break; fi
               echo "PR not found yet, retrying in 5s (attempt $i)..."
               sleep 5
@@ -210,10 +211,18 @@ jobs:
             exit 0
           fi
 
+          release_pr_count=$(gh pr list --repo "$REPO" --state open --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--"))] | length')
+          if [ "$release_pr_count" -ne 1 ]; then
+            echo "::error::Refusing to synchronize with $release_pr_count open Release Please PRs; expected exactly one"
+            exit 1
+          fi
+
           echo "Found release PR branch: $PR_BRANCH"
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
+          REMOTE_SHA=$(git rev-parse "origin/$PR_BRANCH")
           git checkout -f -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
           # Save version-bump files from the release PR branch (release-please output)
@@ -233,23 +242,24 @@ jobs:
           git read-tree --reset -u origin/next
           git clean -fdx
 
-          # Restore version-bump files from the release PR branch
-          for f in CHANGELOG.md package.json src/version.ts .release-please-manifest.json; do
+          # Restore release metadata from the Release Please branch. The generated
+          # package manifest and lockfile remain from next; only the marked version
+          # is overlaid below.
+          for f in CHANGELOG.md src/version.ts .release-please-manifest.json; do
             if [ -f "$STASH_DIR/$f" ]; then
               mkdir -p "$(dirname "$f")"
               cp "$STASH_DIR/$f" "$f"
               git add "$f"
             fi
           done
+
+          python3 .github/scripts/copy_package_version.py "$STASH_DIR/package.json" package.json
+          git add package.json
           rm -rf "$STASH_DIR"
 
-          # release-please changes package.json's version after next's lockfile
-          # was generated. Refresh only the lockfile so frozen CI consumes the
-          # exact release version instead of failing before lint/build.
-          pnpm install --lockfile-only --ignore-scripts
+          # Generated dependency state must be byte-identical to next.
+          git diff --exit-code origin/next -- pnpm-lock.yaml
           pnpm install --frozen-lockfile --ignore-scripts
-          pnpm exec prettier --write pnpm-lock.yaml
-          git add pnpm-lock.yaml
 
           # Commit if there are changes
           if git diff --cached --quiet; then
@@ -271,7 +281,8 @@ jobs:
               fi
             done < <(git show refs/remotes/origin/release-base:CHANGELOG.md | grep '^## ' || true)
 
-            git push --force origin "$PR_BRANCH"
+            gh auth setup-git
+            git push origin HEAD:"$PR_BRANCH" --force-with-lease="$PR_BRANCH:$REMOTE_SHA"
             echo "Successfully synced next code into a clean production-based release PR"
           fi
 
@@ -305,11 +316,11 @@ jobs:
           for attempt in 1 2 3; do
             open_prs=$(gh pr list --repo "$REPO" --state open --json headRefName \
               --jq '[.[] | select(.headRefName | startswith("release-please--"))] | length')
-            [ "$open_prs" -gt 0 ] && break
+            [ "$open_prs" -eq 1 ] && break
             sleep 10
           done
-          if [ "$open_prs" -eq 0 ]; then
-            echo "::error::${unreleased} user-facing + ${releaseas} Release-As commit(s) since ${latest_tag} on next, but no open release PR — release-pr failed silently. Inspect the release-pr step output above."
+          if [ "$open_prs" -ne 1 ]; then
+            echo "::error::expected exactly one open Release Please PR, found ${open_prs}; ${unreleased} user-facing + ${releaseas} Release-As commit(s) exist since ${latest_tag}."
             exit 1
           fi
           echo "Release PR present for unreleased commits — OK."
@@ -317,7 +328,7 @@ jobs:
       - name: Run release-please (github-release)
         if: github.ref == 'refs/heads/master'
         run: |
-          npx release-please github-release \
+          ./node_modules/.bin/release-please github-release \
             --repo-url "${{ github.repositoryUrl }}" \
             --token "${{ secrets.SDK_WRITE_TOKEN }}" \
             --target-branch master \

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Exact-head release PR auto-merge
+name: Exact-head release PR attestation
 
 on:
   pull_request:
@@ -6,6 +6,10 @@ on:
     paths:
       - .github/scripts/release_pr_auto_merge.py
       - .github/scripts/test_release_pr_auto_merge.py
+      - .github/scripts/install_release_please.sh
+      - .github/scripts/test_release_workflow_hardening.py
+      - .github/scripts/copy_package_version.py
+      - .github/scripts/test_copy_package_version.py
       - .github/workflows/release-pr-auto-merge.yml
   pull_request_target:
     branches: [master]
@@ -16,11 +20,6 @@ on:
         description: Release Please PR number
         required: true
         type: number
-      dry_run:
-        description: Attest without merging
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -38,9 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run policy tests
-        run: python3 .github/scripts/test_release_pr_auto_merge.py -v
+        run: |
+          python3 .github/scripts/test_release_pr_auto_merge.py -v
+          python3 .github/scripts/test_release_workflow_hardening.py -v
+          python3 .github/scripts/test_copy_package_version.py -v
       - name: Compile policy
-        run: python3 -m py_compile .github/scripts/release_pr_auto_merge.py .github/scripts/test_release_pr_auto_merge.py
+        run: python3 -m py_compile .github/scripts/release_pr_auto_merge.py .github/scripts/test_release_pr_auto_merge.py .github/scripts/test_release_workflow_hardening.py .github/scripts/copy_package_version.py .github/scripts/test_copy_package_version.py
+      - name: Validate installer shell
+        run: bash -n .github/scripts/install_release_please.sh
 
   gate:
     if: >-
@@ -69,7 +73,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Attest exact head and merge normally
+      - name: Attest exact head without merging
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
@@ -77,24 +81,18 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             PR_NUMBER="$INPUT_PR_NUMBER"
             EXPECTED_HEAD=""
-            DRY_RUN="$INPUT_DRY_RUN"
           else
             PR_NUMBER="$EVENT_PR_NUMBER"
             EXPECTED_HEAD="$EVENT_HEAD_SHA"
-            DRY_RUN="false"
           fi
 
-          args=(--pr-number "$PR_NUMBER")
+          args=(--pr-number "$PR_NUMBER" --dry-run)
           if [ -n "$EXPECTED_HEAD" ]; then
             args+=(--expected-head "$EXPECTED_HEAD")
-          fi
-          if [ "$DRY_RUN" = "true" ]; then
-            args+=(--dry-run)
           fi
           python3 .github/scripts/release_pr_auto_merge.py "${args[@]}"


### PR DESCRIPTION
## What changed
- require exactly one open Release Please PR before synchronization
- pin Release Please to exact version `17.11.2` and verify npm integrity before installation
- make the dormant release PR workflow manual attestation-only; it contains no merge path
- use explicit token-scoped checkout authentication and exact `--force-with-lease` updates
- protect the new policy owners in `next` provenance
- reconcile only the Release Please-owned `package.json` version and preserve the generated manifest/lockfile from `next`

## Why
The previous fleet policy could report green while stale generated manifests or duplicate release PRs remained. This makes release synchronization fail closed against the current `next` tree.

## Durability dependency
- `team-telnyx/telnyx-typescript-staging#325` preserves these production-owned policy files during staging promotion.

## Local validation
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`
- `python3 -m py_compile .github/scripts/*.py`
- `bash -n .github/scripts/install_release_please.sh`
- installer smoke test produced Release Please `17.11.2`
- `git diff --check`
- `actionlint` found no behavioral workflow errors (only pre-existing shellcheck warnings where applicable)
